### PR TITLE
Label archived and outdated articles

### DIFF
--- a/add-theme-and-plugins-to-pelican.html
+++ b/add-theme-and-plugins-to-pelican.html
@@ -117,7 +117,10 @@
     
 </footer><!-- /.post-info -->                    </div>
                 </div>
-                <p>To accomplish this we will change our website to use the excellent pelican-bootstrap3 theme.</p>
+                <div class="alert alert-warning" role="note" aria-label="Outdated content notice">
+<strong>Outdated content.</strong> Originally published on 2019-02-02. Kept for URL continuity and historical context; verify commands, versions, and security guidance against current official documentation before use.
+</div>
+<p>To accomplish this we will change our website to use the excellent pelican-bootstrap3 theme.</p>
 <p>The standard theme that comes with Pelican has one huge disadvantage: it does not display properly on mobile devices.
 To accomplish this we will change our website to use the excellent <a href="https://github.com/getpelican/pelican-themes/tree/master/pelican-bootstrap3">pelican-bootstrap3</a> theme.
 To view the full listing of Pelican themes click <a href="https://github.com/getpelican/pelican-themes">here</a>.</p>

--- a/arbitrage.html
+++ b/arbitrage.html
@@ -114,7 +114,10 @@
     
 </footer><!-- /.post-info -->                    </div>
                 </div>
-                <p>This post is based on <a href="https://scribd.com/document/346123211/High-Frequency-Trading-and-Probability-Theory-Zhaodong-Wang">High Frequency Trading and Probability Theory - Zhaodong Wang</a></p>
+                <div class="alert alert-info" role="note" aria-label="Archive notice">
+<strong>Archive note.</strong> Originally published on 2018-06-06. Preserved for historical context; examples, dependencies, and operational guidance may no longer reflect current practice.
+</div>
+<p>This post is based on <a href="https://scribd.com/document/346123211/High-Frequency-Trading-and-Probability-Theory-Zhaodong-Wang">High Frequency Trading and Probability Theory - Zhaodong Wang</a></p>
 <p>"Here, we will give some detail on how to do real trading using arbitrage.
 There are always many ways to do so, and the method below is just one of
 them. But the key ideas are same."</p>

--- a/candlestick-charts-plotly.html
+++ b/candlestick-charts-plotly.html
@@ -123,7 +123,10 @@
     
 </footer><!-- /.post-info -->                    </div>
                 </div>
-                <h2>Candlesticks Interpretation</h2>
+                <div class="alert alert-info" role="note" aria-label="Archive notice">
+<strong>Archive note.</strong> Originally published on 2019-07-10. Preserved for historical context; examples, dependencies, and operational guidance may no longer reflect current practice.
+</div>
+<h2>Candlesticks Interpretation</h2>
 <p>Perhaps the most common graphical way of displaying commodities price behavior in a giving time frame, candlestick graphs allows us to get a quick and intuitive perception on the stock’s performance. Each candle represents a specific period of analysis (this article will work with daily periods) and informs the opening and closing prices, as well as it’s highs and lows.</p>
 <p><img alt="Candle description" src="images/candle-desc.png"></p>
 <p>The so called “body” of the candle, represented by the thicker area between the opening and closing values, is shown in two different colors — as usual approach: green/white signals a bullish behavior, with the closing price being higher the opening, and red/black demonstrates a bearish behavior, where the price fell lower then it’s opening mark. The third possible case is a “flat-body” type called “doji candles”. This shape of candlestick appears when the active closes at the same (or very near) price that it opened.</p>

--- a/covid-dashboard.html
+++ b/covid-dashboard.html
@@ -120,7 +120,10 @@
     
 </footer><!-- /.post-info -->                    </div>
                 </div>
-                <div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
+                <div class="alert alert-info" role="note" aria-label="Archive notice">
+<strong>Archive note.</strong> Originally published on 2020-10-27. Preserved for historical context; examples, dependencies, and operational guidance may no longer reflect current practice.
+</div>
+<div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
 </div><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <h1 id="From-epidemic-to-pandemic">From epidemic to pandemic<a class="anchor-link" href="#From-epidemic-to-pandemic">&#182;</a></h1><p><img style="float: left; margin:5px 20px 5px 1px; width:40%" src="https://www.nps.gov/aboutus/news/images/CDC-coronavirus-image-23311-for-web.jpg?maxwidth=650&autorotate=false"></p>

--- a/deploying-a-static-website-to-bitbucket.html
+++ b/deploying-a-static-website-to-bitbucket.html
@@ -120,7 +120,10 @@
     
 </footer><!-- /.post-info -->                    </div>
                 </div>
-                <p>We will use BitBucket for the task of hosting a small static website.
+                <div class="alert alert-warning" role="note" aria-label="Outdated content notice">
+<strong>Outdated content.</strong> Originally published on 2019-02-02. Kept for URL continuity and historical context; verify commands, versions, and security guidance against current official documentation before use.
+</div>
+<p>We will use BitBucket for the task of hosting a small static website.
 The service is free and I already use BitBucket repositories to store the source code for my software projects
 so the workflow comes naturally.</p>
 <h4>Goals:</h4>

--- a/essay-paper-template.html
+++ b/essay-paper-template.html
@@ -117,7 +117,10 @@
     
 </footer><!-- /.post-info -->                    </div>
                 </div>
-                <h1>Essay(simple paper) template</h1>
+                <div class="alert alert-info" role="note" aria-label="Archive notice">
+<strong>Archive note.</strong> Originally published on 2020-08-21. Preserved for historical context; examples, dependencies, and operational guidance may no longer reflect current practice.
+</div>
+<h1>Essay(simple paper) template</h1>
 <p>You can download <a href="https://github.com/nekrasovp/nekrasovp.github.io/blob/master/content/essay-paper-template.md">raw Markdown file in blog repository on github</a>.</p>
 <h2>Contents</h2>
 <ul>

--- a/feature-engineering-on-ohlcv-candles-wit-xgboost.html
+++ b/feature-engineering-on-ohlcv-candles-wit-xgboost.html
@@ -129,7 +129,10 @@
     
 </footer><!-- /.post-info -->                    </div>
                 </div>
-                <div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
+                <div class="alert alert-info" role="note" aria-label="Archive notice">
+<strong>Archive note.</strong> Originally published on 2018-12-01. Preserved for historical context; examples, dependencies, and operational guidance may no longer reflect current practice.
+</div>
+<div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
 </div><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <h1 id="Using-XGBoost-regressor-on-Indicators,-ARIMA-and-FFT-of-ohlcv-data">Using XGBoost regressor on Indicators, ARIMA and FFT of ohlcv data<a class="anchor-link" href="#Using-XGBoost-regressor-on-Indicators,-ARIMA-and-FFT-of-ohlcv-data">&#182;</a></h1><p>The goal of this notebook is to apply XGBoost to set of fetures from ohlcv indicators, fft results and arima predictions to test feature importance.</p>

--- a/fixing-caching-sha2-password.html
+++ b/fixing-caching-sha2-password.html
@@ -111,7 +111,10 @@
     
 </footer><!-- /.post-info -->                    </div>
                 </div>
-                <h2>Contents</h2>
+                <div class="alert alert-warning" role="note" aria-label="Outdated content notice">
+<strong>Outdated content.</strong> Originally published on 2022-06-15. Kept for URL continuity and historical context; verify commands, versions, and security guidance against current official documentation before use.
+</div>
+<h2>Contents</h2>
 <ul>
 <li><a href="#contents">Contents</a></li>
 <li><a href="#summary">Summary</a></li>

--- a/install-nvm-node-yarn.html
+++ b/install-nvm-node-yarn.html
@@ -117,7 +117,10 @@
     
 </footer><!-- /.post-info -->                    </div>
                 </div>
-                <h2>Abstract</h2>
+                <div class="alert alert-warning" role="note" aria-label="Outdated content notice">
+<strong>Outdated content.</strong> Originally published on 2022-01-11. Kept for URL continuity and historical context; verify commands, versions, and security guidance against current official documentation before use.
+</div>
+<h2>Abstract</h2>
 <p>The official package manager for node is npm which comes pre-installed with node. You use npm to install yarn — so you do things in this order nvm -&gt; node/npm -&gt; yarn.</p>
 <h2>Contents</h2>
 <ul>

--- a/install-pelican-and-create-project-skeleton.html
+++ b/install-pelican-and-create-project-skeleton.html
@@ -117,7 +117,10 @@
     
 </footer><!-- /.post-info -->                    </div>
                 </div>
-                <p>Building your own static website has several advantages over a traditional website that uses a database to store content. 
+                <div class="alert alert-warning" role="note" aria-label="Outdated content notice">
+<strong>Outdated content.</strong> Originally published on 2019-02-01. Kept for URL continuity and historical context; verify commands, versions, and security guidance against current official documentation before use.
+</div>
+<p>Building your own static website has several advantages over a traditional website that uses a database to store content.
 Static websites are faster because pages are rendered in advance and deliver the same content to all visitors. 
 They are cheaper to host and are more secure since the website has no database.</p>
 <p>Creating each page in a static website one-by-one and updating them when something changes would be very time consuming. 

--- a/markov-chain-bean-machine.html
+++ b/markov-chain-bean-machine.html
@@ -120,7 +120,10 @@
     
 </footer><!-- /.post-info -->                    </div>
                 </div>
-                <div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
+                <div class="alert alert-info" role="note" aria-label="Archive notice">
+<strong>Archive note.</strong> Originally published on 2020-01-25. Preserved for historical context; examples, dependencies, and operational guidance may no longer reflect current practice.
+</div>
+<div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
 </div><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <h1 id="Simulating-a-Galton-board-with-Markov-chains">Simulating a Galton board with Markov chains<a class="anchor-link" href="#Simulating-a-Galton-board-with-Markov-chains">&#182;</a></h1>

--- a/mkrf-spb-geo-data.html
+++ b/mkrf-spb-geo-data.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" prefix="og: http://ogp.me/ns# fb: https://www.facebook.com/2008/fbml">
+<html lang="ru" prefix="og: http://ogp.me/ns# fb: https://www.facebook.com/2008/fbml">
 <head>
     <title>Визуализации картографических данных в Jupyter notebook - Data driven</title>
     <!-- Using the latest rendering mode for IE -->
@@ -120,7 +120,10 @@
     
 </footer><!-- /.post-info -->                    </div>
                 </div>
-                <div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
+                <div class="alert alert-info" role="note" aria-label="Архивная публикация">
+<strong>Архивная публикация.</strong> Впервые опубликовано 2021-04-04. Материал сохранён для исторического контекста; примеры, зависимости и рекомендации могут не соответствовать актуальным версиям.
+</div>
+<div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
 </div><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>В этой статье, мы углубимся в изучение Jupyter Interactive Widgets и Ipyleaflet package, для визуализации картографических данных в Jupyter notebook.</p>

--- a/number-sequences.html
+++ b/number-sequences.html
@@ -117,7 +117,10 @@
     
 </footer><!-- /.post-info -->                    </div>
                 </div>
-                <div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
+                <div class="alert alert-info" role="note" aria-label="Archive notice">
+<strong>Archive note.</strong> Originally published on 2019-08-29. Preserved for historical context; examples, dependencies, and operational guidance may no longer reflect current practice.
+</div>
+<div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
 </div><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <h1 id="Number-sequences">Number sequences<a class="anchor-link" href="#Number-sequences">&#182;</a></h1><p>Visit <a href="http://oeis.org/">The On-Line Encyclopedia of Integer Sequences® (OEIS®) oeis.org</a></p>

--- a/pascals-triangle.html
+++ b/pascals-triangle.html
@@ -123,7 +123,10 @@
     
 </footer><!-- /.post-info -->                    </div>
                 </div>
-                <div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
+                <div class="alert alert-info" role="note" aria-label="Archive notice">
+<strong>Archive note.</strong> Originally published on 2020-08-01. Preserved for historical context; examples, dependencies, and operational guidance may no longer reflect current practice.
+</div>
+<div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
 </div><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <h1 id="Pascal's-Triangle">Pascal's Triangle<a class="anchor-link" href="#Pascal's-Triangle">&#182;</a></h1><p>Check out this link for other implementations and thoughts:</p>

--- a/pelican-github-script-automation.html
+++ b/pelican-github-script-automation.html
@@ -117,7 +117,10 @@
     
 </footer><!-- /.post-info -->                    </div>
                 </div>
-                <p>This blog is powered by <a href="http://docs.getpelican.com/en/stable">Pelican</a> and hosted through 
+                <div class="alert alert-warning" role="note" aria-label="Outdated content notice">
+<strong>Outdated content.</strong> Originally published on 2020-08-22. Kept for URL continuity and historical context; verify commands, versions, and security guidance against current official documentation before use.
+</div>
+<p>This blog is powered by <a href="http://docs.getpelican.com/en/stable">Pelican</a> and hosted through
 GitHub using <a href="https://pages.github.com/">GitHub Pages</a>. </p>
 <p>In this post we will describe how to move blog to github and automate git hooks to update gh
 -pages branch on commits.</p>

--- a/publishing-articles-workflow.html
+++ b/publishing-articles-workflow.html
@@ -117,7 +117,10 @@
     
 </footer><!-- /.post-info -->                    </div>
                 </div>
-                <h2>Abstract</h2>
+                <div class="alert alert-info" role="note" aria-label="Archive notice">
+<strong>Archive note.</strong> Originally published on 2020-09-09. Preserved for historical context; examples, dependencies, and operational guidance may no longer reflect current practice.
+</div>
+<h2>Abstract</h2>
 <p>In this article, I would like to document my blogging experience. 
 After writing and distributing articles for a long time, 
 I kind of set up a framework when it comes to distributing articles. 

--- a/retrospective-template.html
+++ b/retrospective-template.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" prefix="og: http://ogp.me/ns# fb: https://www.facebook.com/2008/fbml">
+<html lang="ru" prefix="og: http://ogp.me/ns# fb: https://www.facebook.com/2008/fbml">
 <head>
     <title>Шаблон ретроспективы - Data driven</title>
     <!-- Using the latest rendering mode for IE -->

--- a/setting-up-nginx-gunicorn-flask.html
+++ b/setting-up-nginx-gunicorn-flask.html
@@ -120,7 +120,10 @@
     
 </footer><!-- /.post-info -->                    </div>
                 </div>
-                <h2>Abstract</h2>
+                <div class="alert alert-warning" role="note" aria-label="Outdated content notice">
+<strong>Outdated content.</strong> Originally published on 2021-11-03. Kept for URL continuity and historical context; verify commands, versions, and security guidance against current official documentation before use.
+</div>
+<h2>Abstract</h2>
 <p>In this article we will to go through the process of deploying a flask app on a Linux server. We will use gunicorn as a WSGI server to communicate with our flask app, and Nginx as a proxy server between the gunicorn server and the client.</p>
 <p>We need gunicorn between flask and nginx because the flask development server although good for debugging is weak and will not stand in production, so we need gunicorn as a wsgi server to communicate with flask.</p>
 <h2>Contents</h2>

--- a/share-data.html
+++ b/share-data.html
@@ -114,7 +114,10 @@
     
 </footer><!-- /.post-info -->                    </div>
                 </div>
-                <p>Initial article was writen by <a href="http://biostat.jhsph.edu/~jleek/">Jeff Leek</a></p>
+                <div class="alert alert-info" role="note" aria-label="Archive notice">
+<strong>Archive note.</strong> Originally published on 2020-09-29. Preserved for historical context; examples, dependencies, and operational guidance may no longer reflect current practice.
+</div>
+<p>Initial article was writen by <a href="http://biostat.jhsph.edu/~jleek/">Jeff Leek</a></p>
 <h2>Contents</h2>
 <ul>
 <li><a href="#abstract">Abstract</a></li>

--- a/stock-data-with-pandas-datareader.html
+++ b/stock-data-with-pandas-datareader.html
@@ -120,7 +120,10 @@
     
 </footer><!-- /.post-info -->                    </div>
                 </div>
-                <div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
+                <div class="alert alert-info" role="note" aria-label="Archive notice">
+<strong>Archive note.</strong> Originally published on 2019-03-01. Preserved for historical context; examples, dependencies, and operational guidance may no longer reflect current practice.
+</div>
+<div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
 </div><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>The goal of this article is to provide an easy introduction to stock market analysis using Python. In this notebook we will use pandas_datareader module. We will walk through a simple Python script to retrieve, analyze, and visualize data from different markets.</p>

--- a/stock-perfomance-analysis.html
+++ b/stock-perfomance-analysis.html
@@ -123,7 +123,10 @@
     
 </footer><!-- /.post-info -->                    </div>
                 </div>
-                <div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
+                <div class="alert alert-info" role="note" aria-label="Archive notice">
+<strong>Archive note.</strong> Originally published on 2019-07-11. Preserved for historical context; examples, dependencies, and operational guidance may no longer reflect current practice.
+</div>
+<div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
 </div><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <h2 id="Introduction-to-ffn">Introduction to ffn<a class="anchor-link" href="#Introduction-to-ffn">&#182;</a></h2><p>Data related works in Python are usually done using libraries such as Numpy, Pandas or Scipy, giving that these libraries are not only resourceful and versatile, but they’re well known to the data science community as fundamental Python skills. Having said that, quantitative finance professionals can count on a free open-source library built over the ones mentioned before, which provide straight-forward and easy solutions for finance, check out: <a href="http://pmorissette.github.io/ffn/">ffn</a></p>

--- a/technical-debt-examples.html
+++ b/technical-debt-examples.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" prefix="og: http://ogp.me/ns# fb: https://www.facebook.com/2008/fbml">
+<html lang="ru" prefix="og: http://ogp.me/ns# fb: https://www.facebook.com/2008/fbml">
 <head>
     <title>Примеры технического долга - Data driven</title>
     <!-- Using the latest rendering mode for IE -->

--- a/testing-hypothesis-on-football-data-set.html
+++ b/testing-hypothesis-on-football-data-set.html
@@ -132,7 +132,10 @@
     
 </footer><!-- /.post-info -->                    </div>
                 </div>
-                <div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
+                <div class="alert alert-info" role="note" aria-label="Archive notice">
+<strong>Archive note.</strong> Originally published on 2019-05-10. Preserved for historical context; examples, dependencies, and operational guidance may no longer reflect current practice.
+</div>
+<div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
 </div><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>One way ANOVA (Analysis of Variance) is a technique for hypothesis testing. It is used to test whether the means of different group is really different.</p>

--- a/upgrading-openssl-ubuntu.html
+++ b/upgrading-openssl-ubuntu.html
@@ -117,7 +117,10 @@
     
 </footer><!-- /.post-info -->                    </div>
                 </div>
-                <p>To avoid openssl and TLS version issue we will update openSSL on server and desktop version of Ubuntu 18.04</p>
+                <div class="alert alert-warning" role="note" aria-label="Outdated content notice">
+<strong>Outdated content.</strong> Originally published on 2019-02-05. Kept for URL continuity and historical context; verify commands, versions, and security guidance against current official documentation before use.
+</div>
+<p>To avoid openssl and TLS version issue we will update openSSL on server and desktop version of Ubuntu 18.04</p>
 <p>We will download it manually, install and make necessary file permission changes.</p>
 <p>Let's begin with fetching the tarball from official site.</p>
 <div class="highlight"><pre><span></span><code>➜  wget https://www.openssl.org/source/openssl-1.1.1b.tar.gz

--- a/use-cython-to-speedup-your-python-code.html
+++ b/use-cython-to-speedup-your-python-code.html
@@ -114,7 +114,10 @@
     
 </footer><!-- /.post-info -->                    </div>
                 </div>
-                <div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
+                <div class="alert alert-info" role="note" aria-label="Archive notice">
+<strong>Archive note.</strong> Originally published on 2019-09-02. Preserved for historical context; examples, dependencies, and operational guidance may no longer reflect current practice.
+</div>
+<div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
 </div><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>If we have a code on pure Python usually we can speed it up with some tiny changes using Cython.</p>

--- a/what-is-technical-debt.html
+++ b/what-is-technical-debt.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" prefix="og: http://ogp.me/ns# fb: https://www.facebook.com/2008/fbml">
+<html lang="ru" prefix="og: http://ogp.me/ns# fb: https://www.facebook.com/2008/fbml">
 <head>
     <title>Что такое технический долг? - Data driven</title>
     <!-- Using the latest rendering mode for IE -->


### PR DESCRIPTION
## Summary

This third stacked PR applies the reviewed archive classification without deleting routes or changing historical publication dates:

- adds an archive notice to 16 preserved historical articles;
- adds a stronger outdated-content warning to 8 version-sensitive articles;
- tells readers to verify commands, versions, and security guidance against current official documentation;
- corrects the document language to `lang="ru"` on all 4 Russian-language legacy articles;
- intentionally does **not** add `noindex`, redirects, or silent date changes.

## Review order

1. Merge #53.
2. Retarget and merge #54.
3. Retarget this PR to `gh-pages` only after #54 lands.

## Verification

- every one of the 46 inventory rows maps to an existing article route;
- exactly 16 archive notices and 8 outdated-content notices are present;
- notice dates match the original publication dates in the inventory;
- all 4 Russian articles declare `lang="ru"`;
- no notice appears on `keep` or `refresh` rows;
- no article gains `noindex`;
- `git diff --check` passes.

This PR remains a draft and is not merged.