### PR TITLE
Add Russian HR landing

### DIFF
--- a/404.html
+++ b/404.html
@@ -18,6 +18,7 @@
         <li><a href="/writing/">Writing</a></li>
         <li><a href="/about/">About</a></li>
         <li><a href="https://github.com/nekrasovp">GitHub</a></li>
+        <li class="language-switch"><a href="/ru/" lang="ru" hreflang="ru">RU</a></li>
       </ul>
     </nav>
   </header>

--- a/about/index.html
+++ b/about/index.html
@@ -29,6 +29,7 @@
         <li><a href="/writing/">Writing</a></li>
         <li><a href="/about/" aria-current="page">About</a></li>
         <li><a href="https://github.com/nekrasovp">GitHub</a></li>
+        <li class="language-switch"><a href="/ru/#background" lang="ru" hreflang="ru">RU</a></li>
       </ul>
     </nav>
   </header>

--- a/assets/site.css
+++ b/assets/site.css
@@ -131,6 +131,21 @@ img {
   color: var(--text);
 }
 
+.nav-links .language-switch a {
+  display: inline-flex;
+  align-items: center;
+  min-height: 30px;
+  padding: 2px 9px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  color: var(--text);
+  letter-spacing: 0.06em;
+}
+
+.nav-links .language-switch a:hover {
+  border-color: var(--accent);
+}
+
 .hero {
   min-height: 680px;
   display: grid;
@@ -161,6 +176,10 @@ h1 {
   max-width: 880px;
   margin: 0;
   font-size: clamp(48px, 7.3vw, 92px);
+}
+
+.ru-page .hero h1 {
+  font-size: clamp(40px, 6.4vw, 82px);
 }
 
 h2 {

--- a/index.html
+++ b/index.html
@@ -6,6 +6,9 @@
   <title>Pavel Nekrasov — Tech Lead &amp; Backend/Platform Engineer</title>
   <meta name="description" content="Pavel Nekrasov is a Tech Lead and staff-level backend/platform engineer building distributed systems, engineering platforms, and delivery workflows.">
   <link rel="canonical" href="https://nekrasovp.ru/">
+  <link rel="alternate" hreflang="en" href="https://nekrasovp.ru/">
+  <link rel="alternate" hreflang="ru" href="https://nekrasovp.ru/ru/">
+  <link rel="alternate" hreflang="x-default" href="https://nekrasovp.ru/">
   <link rel="icon" href="/images/logo2.png">
   <link rel="stylesheet" href="/assets/site.css">
   <meta property="og:type" content="website">
@@ -51,6 +54,7 @@
         <li><a href="/writing/">Writing</a></li>
         <li><a href="/about/">About</a></li>
         <li><a href="https://github.com/nekrasovp">GitHub</a></li>
+        <li class="language-switch"><a href="/ru/" lang="ru" hreflang="ru">RU</a></li>
       </ul>
     </nav>
   </header>
@@ -69,8 +73,8 @@
       <aside class="hero-panel" aria-label="Current focus">
         <div class="monogram" aria-hidden="true">PN</div>
         <div class="status-label">Current focus</div>
-        <p class="status-value">Navio · Open source · HZProtocol (part-time)</p>
-        <p class="status-note">Backend architecture, AI-assisted SDLC/PDLC pilots, prediction-market infrastructure, and production Python.</p>
+        <p class="status-value">Navio · Backend/platform engineering · Open source</p>
+        <p class="status-note">Backend architecture, AI-assisted SDLC/PDLC pilots, engineering governance, and production Python.</p>
       </aside>
     </section>
 
@@ -85,10 +89,10 @@
       </div>
     </section>
 
-    <section class="section" id="current-work">
+    <section class="section" id="selected-work">
       <div class="container">
         <div class="section-heading">
-          <div><p class="eyebrow">Current work</p><h2>Code, architecture, and the operating model.</h2></div>
+          <div><p class="eyebrow">Selected work</p><h2>Code, architecture, and the operating model.</h2></div>
           <p class="section-intro">My strongest work happens where product pressure, technical complexity, and organizational change meet. I combine hands-on engineering with explicit ownership of architecture, hiring, technical debt, and delivery practices.</p>
         </div>
         <div class="grid grid-3">
@@ -99,10 +103,10 @@
             <a class="card-link" href="/work/#navio">Role and outcomes →</a>
           </article>
           <article class="card">
-            <div class="card-kicker">HZProtocol</div>
-            <h3>ArbLense and prediction-market infrastructure</h3>
-            <p>Part-time Co-founder and CTO: product vision, architecture, code, DevOps, and the path from early product iterations to live use and growth.</p>
-            <a class="card-link" href="https://github.com/hzprotocol">Explore HZProtocol →</a>
+            <div class="card-kicker">Platform engineering</div>
+            <h3>Reusable foundations for production services</h3>
+            <p>Shared observability components, high-load proxy protections, service standards, and architecture practices that improve diagnostics and delivery.</p>
+            <a class="card-link" href="/work/">Backend and platform outcomes →</a>
           </article>
           <article class="card">
             <div class="card-kicker">Open source</div>

--- a/ru/index.html
+++ b/ru/index.html
@@ -1,0 +1,229 @@
+<!doctype html>
+<html lang="ru">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Павел Некрасов — Tech Lead, Python Backend и Platform Engineering</title>
+  <meta name="description" content="Tech Lead и senior Python backend/platform engineer: архитектура распределённых систем, инженерные платформы, техническое лидерство и SDLC.">
+  <link rel="canonical" href="https://nekrasovp.ru/ru/">
+  <link rel="alternate" hreflang="ru" href="https://nekrasovp.ru/ru/">
+  <link rel="alternate" hreflang="en" href="https://nekrasovp.ru/">
+  <link rel="alternate" hreflang="x-default" href="https://nekrasovp.ru/">
+  <link rel="icon" href="/images/logo2.png">
+  <link rel="stylesheet" href="/assets/site.css">
+  <meta property="og:type" content="profile">
+  <meta property="og:locale" content="ru_RU">
+  <meta property="og:title" content="Павел Некрасов — Tech Lead и Backend/Platform Engineer">
+  <meta property="og:description" content="Архитектура, Python backend, инженерные платформы и техническое лидерство с опорой на реальную эксплуатацию.">
+  <meta property="og:url" content="https://nekrasovp.ru/ru/">
+  <meta property="og:image" content="https://nekrasovp.ru/images/social-preview.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:alt" content="Павел Некрасов — Tech Lead и Backend/Platform Engineer">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:image" content="https://nekrasovp.ru/images/social-preview.png">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Person",
+    "name": "Павел Некрасов",
+    "url": "https://nekrasovp.ru/ru/",
+    "jobTitle": "Tech Lead и Backend/Platform Engineer",
+    "knowsLanguage": ["ru", "en"],
+    "sameAs": [
+      "https://github.com/nekrasovp",
+      "https://www.linkedin.com/in/nekrasovp/",
+      "https://t.me/def12"
+    ],
+    "knowsAbout": [
+      "Python backend",
+      "Архитектура распределённых систем",
+      "Platform engineering",
+      "Техническое лидерство",
+      "SDLC",
+      "Логистика и управление цепями поставок"
+    ]
+  }
+  </script>
+</head>
+<body class="ru-page">
+  <a class="skip-link" href="#main">Перейти к содержанию</a>
+  <header class="site-header">
+    <nav class="nav container" aria-label="Основная навигация">
+      <a class="brand" href="/ru/" aria-current="page"><span class="brand-mark">PN</span><span>Павел Некрасов</span></a>
+      <ul class="nav-links">
+        <li><a href="#results">Результаты</a></li>
+        <li><a href="#experience">Опыт</a></li>
+        <li><a href="#background">Бэкграунд</a></li>
+        <li><a href="#writing">Статьи</a></li>
+        <li><a href="https://github.com/nekrasovp">GitHub</a></li>
+        <li class="language-switch"><a href="/" lang="en" hreflang="en">EN</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main id="main">
+    <section class="hero container">
+      <div>
+        <p class="eyebrow">Техническое лидерство с опорой на реальную эксплуатацию</p>
+        <h1>Строю backend-системы, платформы и инженерные процессы.</h1>
+        <p class="lede">Tech Lead и senior Python backend/platform engineer. Совмещаю работу с кодом, архитектуру, техническое лидерство и развитие процессов поставки в сложных продуктовых системах.</p>
+        <div class="actions">
+          <a class="button button-primary" href="#experience">Опыт и результаты</a>
+          <a class="button button-secondary" href="mailto:nekrasovp@gmail.com">Связаться</a>
+        </div>
+      </div>
+      <aside class="hero-panel" aria-label="Текущий фокус">
+        <div class="monogram" aria-hidden="true">PN</div>
+        <div class="status-label">Текущий фокус</div>
+        <p class="status-value">Navio · Backend и platform engineering · Open source</p>
+        <p class="status-note">Архитектура backend-систем, инженерные стандарты, технический долг, найм и AI-assisted SDLC/PDLC.</p>
+      </aside>
+    </section>
+
+    <section class="section" id="results">
+      <div class="container">
+        <div class="metrics" aria-label="Масштаб опыта">
+          <div class="metric"><strong>7+ лет</strong><span>в backend- и platform-разработке</span></div>
+          <div class="metric"><strong>до 20</strong><span>backend-инженеров с учётом подрядчиков; около 10 в прямом контуре</span></div>
+          <div class="metric"><strong>≈100</strong><span>сервисов в контуре развивающегося архитектурного управления</span></div>
+          <div class="metric"><strong>30k RPS</strong><span>пиковая нагрузка production-прокси</span></div>
+        </div>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="container">
+        <div class="section-heading">
+          <div><p class="eyebrow">Ключевые результаты</p><h2>Архитектура, поставка и эксплуатация.</h2></div>
+          <p class="section-intro">Моя сильная сторона — соединять продуктовый контекст, инженерные решения и способ работы команды, сохраняя связь с реализацией и production.</p>
+        </div>
+        <div class="grid grid-3">
+          <article class="card">
+            <div class="card-kicker">Архитектура</div>
+            <h3>Платформы из десятков сервисов</h3>
+            <p>Развивал архитектурные подходы для API Gateway, OPA/RBAC, аудита, Kafka-интеграций, auth context и асинхронных сценариев в ландшафте, выросшем примерно с 30 до 100 сервисов.</p>
+          </article>
+          <article class="card">
+            <div class="card-kicker">Техническое лидерство</div>
+            <h3>Команда и инженерная система</h3>
+            <p>Отвечал за найм backend-разработчиков, постановку целей, performance review, архитектурный контроль, CODEOWNERS и системную работу с техническим долгом.</p>
+          </article>
+          <article class="card">
+            <div class="card-kicker">High load</div>
+            <h3>Защита production-прокси</h3>
+            <p>Разработал CIDR-фильтрацию для Django-прокси с пиковой нагрузкой около 30k RPS, интегрированную с Kubernetes и WAF, а также общие инструменты логирования и диагностики.</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="section" id="experience">
+      <div class="container">
+        <div class="section-heading">
+          <div><p class="eyebrow">Опыт</p><h2>Роли и ожидаемые результаты.</h2></div>
+          <p class="section-intro">Последовательность ролей показывает рост от backend-разработки к ответственности за архитектуру, качество инженерной системы, найм и устойчивость поставки.</p>
+        </div>
+        <div class="timeline">
+          <article class="timeline-item">
+            <div class="timeline-date">Март 2025 — настоящее время</div>
+            <div class="timeline-copy">
+              <h3>Navio · Tech Lead</h3>
+              <p>Отвечаю за backend-архитектуру и техническое направление автомобильных, логистических и fleet-management платформ. Сознательно сохраняю 30–60% времени на реализацию, code review и работу с production.</p>
+              <p>Развиваю архитектурные ревью, сервисные стандарты, CODEOWNERS и управление техническим долгом. Веду активный AI-assisted SDLC/PDLC-пилот с автоматизацией Jira, проверками документов, DoR/DoD и human-controlled решениями.</p>
+            </div>
+          </article>
+          <article class="timeline-item">
+            <div class="timeline-date">Апрель 2024 — февраль 2025</div>
+            <div class="timeline-copy">
+              <h3>Navio · Backend Team Lead</h3>
+              <p>Руководил backend-поставкой в контуре до 20 инженеров с учётом внешних подрядчиков; около 10 разработчиков находились в прямом управлении.</p>
+              <p>Отвечал за найм, цели, performance review, релизную координацию и технический долг. Стандартизировал логирование, метрики и трассировку через общие Python-библиотеки и middleware.</p>
+            </div>
+          </article>
+          <article class="timeline-item">
+            <div class="timeline-date">Июнь 2022 — апрель 2024</div>
+            <div class="timeline-copy">
+              <h3>Ruform / экосистема RUTUBE · Backend Developer</h3>
+              <p>Разрабатывал внутренние инструменты, общую ELK-ориентированную библиотеку логирования, CIDR-фильтрацию и высоконагруженные прокси для поиска, подсказок и рекомендаций.</p>
+              <p>Участвовал в развитии SDLC компании: уточнении DoR/DoD, требований и delivery gates для более предсказуемых релизов и ответственности.</p>
+            </div>
+          </article>
+          <article class="timeline-item">
+            <div class="timeline-date">2020 — 2022 · part-time</div>
+            <div class="timeline-copy">
+              <h3>MyOpenTour · Сооснователь, CTO, Backend и DevOps</h3>
+              <p>Отвечал за техническую часть инвестиционного travel-стартапа: архитектуру, backend, инфраструктуру, CI/CD и управление двумя frontend-разработчиками в команде до семи человек.</p>
+            </div>
+          </article>
+          <article class="timeline-item">
+            <div class="timeline-date">2019 — 2022</div>
+            <div class="timeline-copy">
+              <h3>Backend и quantitative engineering</h3>
+              <p>Разрабатывал Python-инструменты для исследований и исполнения, интеграции с биржами, ETL, ClickHouse-аналитику, REST API и сервисы обработки временных рядов.</p>
+            </div>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="section" id="background">
+      <div class="container">
+        <div class="section-heading">
+          <div><p class="eyebrow">До разработки</p><h2>Логистика, торговля и сложные цепочки поставок.</h2></div>
+          <div class="prose">
+            <p>До перехода в разработку я более десяти лет управлял логистическими и торговыми направлениями. Владел московской курьерской компанией LastMileLogistic, которая выросла более чем до 50 сотрудников.</p>
+            <p>Отвечал за продажи, IT-системы, складские процессы, финансовую модель и небольшие кросс-функциональные команды. Организовывал северный завоз для золотодобывающих компаний, сложные промышленные поставки, сервис и снабжение грузовой и специальной техники.</p>
+            <p>Этот опыт влияет на инженерные решения: архитектура — это операционная модель; локальная оптимизация может ухудшить всю систему; надёжность, очереди, handoff и ответственность имеют прямую стоимость.</p>
+            <p><strong>MBA «Логистика и управление цепями поставок»</strong> — Международный центр логистики НИУ ВШЭ (MCLOG).</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="section" id="writing">
+      <div class="container">
+        <div class="section-heading">
+          <div><p class="eyebrow">Статьи на русском</p><h2>Инженерная практика без лишней теории.</h2></div>
+          <p class="section-intro">Русскоязычные материалы сохранены в архиве. Новые подробные тексты о backend, архитектуре и инженерном управлении публикуются преимущественно на английском.</p>
+        </div>
+        <div class="article-list">
+          <a class="article-item" href="/technical-debt-examples.html"><span class="article-date">14 октября 2023 · RU</span><div class="article-copy"><h3>Примеры технического долга</h3><p>Как технический долг проявляется в существующем коде и системах.</p></div><span class="article-arrow" aria-hidden="true">↗</span></a>
+          <a class="article-item" href="/what-is-technical-debt.html"><span class="article-date">16 сентября 2023 · RU</span><div class="article-copy"><h3>Что такое технический долг?</h3><p>Определения, профилактика и практики, которые помогают сохранять долг видимым.</p></div><span class="article-arrow" aria-hidden="true">↗</span></a>
+          <a class="article-item" href="/retrospective-template.html"><span class="article-date">11 февраля 2021 · RU</span><div class="article-copy"><h3>Шаблон ретроспективы</h3><p>Практическая структура командной ретроспективы.</p></div><span class="article-arrow" aria-hidden="true">↗</span></a>
+        </div>
+        <div class="actions"><a class="button button-secondary" href="/writing/">Все статьи и английский архив →</a></div>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="container">
+        <div class="section-heading">
+          <div><p class="eyebrow">Контакт</p><h2>Готов обсуждать сложные продуктовые и инженерные задачи.</h2></div>
+          <div>
+            <p class="section-intro">Наиболее релевантные направления: Tech Lead, Staff/Platform Engineer и Senior Python Backend Engineer. Москва, предпочитаю удалённую работу, открыт к релокации.</p>
+            <div class="actions">
+              <a class="button button-primary" href="https://t.me/def12">Telegram</a>
+              <a class="button button-secondary" href="mailto:nekrasovp@gmail.com">Email</a>
+              <a class="button button-secondary" href="https://github.com/nekrasovp">GitHub</a>
+              <a class="button button-secondary" href="https://www.linkedin.com/in/nekrasovp/">LinkedIn</a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="footer-row container">
+      <span>© 2026 Павел Некрасов</span>
+      <div class="footer-links">
+        <a href="https://github.com/nekrasovp">GitHub</a>
+        <a href="https://www.linkedin.com/in/nekrasovp/">LinkedIn</a>
+        <a href="https://t.me/def12">Telegram</a>
+        <a href="mailto:nekrasovp@gmail.com">Email</a>
+      </div>
+    </div>
+  </footer>
+</body>
+</html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,52 +2,57 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://nekrasovp.ru/</loc>
-    <lastmod>2026-07-15</lastmod>
+    <lastmod>2026-07-16</lastmod>
     <priority>1.0</priority>
   </url>
   <url>
+    <loc>https://nekrasovp.ru/ru/</loc>
+    <lastmod>2026-07-16</lastmod>
+    <priority>0.95</priority>
+  </url>
+  <url>
     <loc>https://nekrasovp.ru/work/</loc>
-    <lastmod>2026-07-15</lastmod>
+    <lastmod>2026-07-16</lastmod>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://nekrasovp.ru/writing/</loc>
-    <lastmod>2026-07-15</lastmod>
+    <lastmod>2026-07-16</lastmod>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://nekrasovp.ru/about/</loc>
-    <lastmod>2026-07-15</lastmod>
+    <lastmod>2026-07-16</lastmod>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://nekrasovp.ru/technical-debt-as-a-portfolio.html</loc>
-    <lastmod>2026-07-15</lastmod>
+    <lastmod>2026-07-16</lastmod>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://nekrasovp.ru/ai-native-sdlc-engineering-accountability.html</loc>
-    <lastmod>2026-07-15</lastmod>
+    <lastmod>2026-07-16</lastmod>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://nekrasovp.ru/logistics-lessons-for-distributed-systems.html</loc>
-    <lastmod>2026-07-15</lastmod>
+    <lastmod>2026-07-16</lastmod>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://nekrasovp.ru/technical-debt-portfolio-register.html</loc>
-    <lastmod>2026-07-15</lastmod>
+    <lastmod>2026-07-16</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://nekrasovp.ru/ai-native-delivery-contract.html</loc>
-    <lastmod>2026-07-15</lastmod>
+    <lastmod>2026-07-16</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://nekrasovp.ru/logistics-distributed-systems-case-study.html</loc>
-    <lastmod>2026-07-15</lastmod>
+    <lastmod>2026-07-16</lastmod>
     <priority>0.6</priority>
   </url>
   <url>

--- a/work/index.html
+++ b/work/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Work — Pavel Nekrasov</title>
-  <meta name="description" content="Selected engineering leadership, backend architecture, product work, startups, and open-source projects by Pavel Nekrasov.">
+  <meta name="description" content="Selected engineering leadership, backend architecture, high-load systems, and open-source projects by Pavel Nekrasov.">
   <link rel="canonical" href="https://nekrasovp.ru/work/">
   <link rel="icon" href="/images/logo2.png">
   <link rel="stylesheet" href="/assets/site.css">
@@ -29,6 +29,7 @@
         <li><a href="/writing/">Writing</a></li>
         <li><a href="/about/">About</a></li>
         <li><a href="https://github.com/nekrasovp">GitHub</a></li>
+        <li class="language-switch"><a href="/ru/#experience" lang="ru" hreflang="ru">RU</a></li>
       </ul>
     </nav>
   </header>
@@ -72,13 +73,6 @@
               <h3>Navio · Backend Team Lead</h3>
               <p>Led backend delivery for up to 20 engineers including external contractors, with around 10 backend engineers in direct management scope. Owned backend hiring, goal setting, performance reviews, release coordination, and technical-debt planning while remaining involved in implementation and production support.</p>
               <p>Standardized logging, metrics, and tracing through shared Python libraries and middleware, improving production diagnostics and service onboarding consistency.</p>
-            </div>
-          </article>
-          <article class="timeline-item">
-            <div class="timeline-date">Oct 2025 — Present · part-time</div>
-            <div class="timeline-copy">
-              <h3>HZProtocol / ArbLense · Co-founder &amp; CTO</h3>
-              <p>In this part-time founder role, own product direction, architecture, code, DevOps, and business development for prediction-market intelligence products. Co-created the ArbLense vision and developed the product from early iterations through live use, traffic planning, and investor preparation.</p>
             </div>
           </article>
           <article class="timeline-item">

--- a/writing/index.html
+++ b/writing/index.html
@@ -30,6 +30,7 @@
         <li><a href="/writing/" aria-current="page">Writing</a></li>
         <li><a href="/about/">About</a></li>
         <li><a href="https://github.com/nekrasovp">GitHub</a></li>
+        <li class="language-switch"><a href="/ru/#writing" lang="ru" hreflang="ru">RU</a></li>
       </ul>
     </nav>
   </header>


### PR DESCRIPTION
## What changed
- added a Russian HR-focused landing page at `/ru/`
- added RU/EN language switches across key pages
- removed current founder positioning from the default English Home and Work pages
- kept MyOpenTour as historical experience and HZProtocol only as a technical project
- updated sitemap and responsive styles

## Validation
- parsed all changed HTML and JSON-LD locally
- validated sitemap XML and URL uniqueness
- checked desktop and mobile layouts without horizontal overflow
- verified the branch is one commit ahead of `gh-pages`