### PR TITLE
SITE-003: Normalize legacy article metadata

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+theme/templates/*.html whitespace=cr-at-eol
+theme/templates/includes/*.html whitespace=cr-at-eol

--- a/.github/workflows/site002v.yml
+++ b/.github/workflows/site002v.yml
@@ -1,4 +1,4 @@
-name: SITE-002V
+name: SITE-002V and SITE-003
 
 on:
   pull_request:
@@ -18,7 +18,7 @@ env:
 
 jobs:
   immutable-reader:
-    name: Immutable reader and 46-article corpus
+    name: Immutable reader and normalized 46-article corpus
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
@@ -51,7 +51,7 @@ jobs:
               print(f"{name}=={version(name)}")
           PY
 
-      - name: Run two full builds and all SITE-002V gates
+      - name: Run two full builds and SITE-002V plus SITE-003 gates
         run: |
           ./scripts/site validate \
             --work-root "$RUNNER_TEMP/site002v" \
@@ -63,7 +63,8 @@ jobs:
         run: |
           ./scripts/site test
           uv run --locked --all-groups ruff check \
-            migration/site_build migration/site002v/validate.py
+            migration/site_build migration/site002v/validate.py \
+            migration/site003 plugins/site_metadata.py
           git diff --check
           test -z "$(git status --porcelain=v1 --untracked-files=all)"
           github_token_prefix='github''_pat_'

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 help:
 	@echo 'make markdown  Markdown-only smoke build (warnings are errors)'
 	@echo 'make build     Full production-intent build (46 historical articles)'
-	@echo 'make validate  Full SITE-002V deterministic and negative gates'
+	@echo 'make validate  Full SITE-002V/SITE-003 deterministic and negative gates'
 	@echo 'make serve     Local Markdown-only server (PORT=8000 by default)'
 	@echo 'make test      SITE-001 acceptance tests'
 

--- a/content/Getting-stock-data-with-pandas-datareader.nbdata
+++ b/content/Getting-stock-data-with-pandas-datareader.nbdata
@@ -4,6 +4,6 @@ Date: 2019-03-01 15:00
 Category: Blog
 Tags: python, notebook, finance, pandas
 Slug: stock-data-with-pandas-datareader
+Lang: en
+Status: archive
 Summary: The goal of this article is to provide an easy introduction to stock market analysis using Python. In this notebook we will use pandas_datareader module. We will walk through a simple Python script to retrieve, analyze, and visualize data from different markets.
-
-

--- a/content/Number-sequences.nbdata
+++ b/content/Number-sequences.nbdata
@@ -1,7 +1,9 @@
-Title: Number sequences visualisation with python
+Title: Number-sequence visualization with Python
 Author: Nekrasov Pavel
 Date: 2019-08-29 15:00
 Category: Blog
 Tags: python, notebook, numpy
 Slug: number-sequences
+Lang: en
+Status: archive
 Summary: In this notebook we will compute and visualise some famous and nice looking number sequences.

--- a/content/Retrospective-template.md
+++ b/content/Retrospective-template.md
@@ -4,6 +4,8 @@ Date: 2021-02-11 11:00
 Category: Blog
 Tags: workflow, template
 Slug: retrospective-template
+Lang: ru
+Status: refresh
 Summary: Шаблон для проведения ретроспективы на русским языке
 
 # Оглавление

--- a/content/Stock-market-portfolio-optimisation.nbdata
+++ b/content/Stock-market-portfolio-optimisation.nbdata
@@ -1,7 +1,9 @@
-Title: Stock market portfolio optimisation
+Title: Stock-market portfolio optimization
 Author: Nekrasov Pavel
 Date: 2019-07-12 15:00
 Category: Blog
 Tags: python, notebook, finance, pandas, portfolio
 Slug: stock-market-portfolio-optimisation
+Lang: en
+Status: archive
 Summary: The goal of this notebook is to provide an introduction to stock market portfolio optimisation using Python.

--- a/content/Testing-hypothesis-on-football-data-set.nbdata
+++ b/content/Testing-hypothesis-on-football-data-set.nbdata
@@ -1,7 +1,9 @@
-Title: Testing hypothesis on football data-set from kaggle
+Title: Testing a hypothesis on a football data set from Kaggle
 Author: Nekrasov Pavel
 Date: 2019-05-10 15:00
 Category: Blog
 Tags: python, notebook, statistics, pandas, kaggle, seaborn, matplotlib, ANOVA
 Slug: testing-hypothesis-on-football-data-set
+Lang: en
+Status: archive
 Summary: In this notebook we will use the data-set, International football results from 1872 to 2019. We will try ANOVA hypothesis testing technique.

--- a/content/Use Cython to speed up your Python code.nbdata
+++ b/content/Use Cython to speed up your Python code.nbdata
@@ -1,7 +1,9 @@
-Title: Use Cython to speed up your Python code
+Title: Use Cython to speed up Python code
 Author: Nekrasov Pavel
 Date: 2019-09-02 15:00
 Category: Blog
 Tags: python, cython
 Slug: use-cython-to-speedup-your-python-code
+Lang: en
+Status: archive
 Summary: In this notebook will try to convert pure Python code to Cython and test speed up with magic functions.

--- a/content/add-theme-and-plugins-to-pelican.md
+++ b/content/add-theme-and-plugins-to-pelican.md
@@ -1,9 +1,11 @@
-Title: Add theme and plugins to Pelican installation
+Title: Add a theme and plugins to Pelican
 Author: Nekrasov Pavel
 Date: 2019-02-02 16:00
 Category: Blog
 Tags: python, markdown, pelican
 Slug: add-theme-and-plugins-to-pelican
+Lang: en
+Status: deprecated
 Summary: The standard theme that comes with Pelican has one huge disadvantage: it does not display properly on mobile devices.
 To accomplish this we will change our website to use the excellent pelican-bootstrap3 theme.
 

--- a/content/analytics-checklist.md
+++ b/content/analytics-checklist.md
@@ -4,6 +4,8 @@ Date: 2022-02-10 15:00
 Category: Blog
 Tags: analytics, template
 Slug: analytics-checklist
+Lang: en
+Status: keep
 Summary: Five ways to help users become more data-driven in order to guarantee the success of your analytics project
 
 ## Abstract

--- a/content/arbitrage.md
+++ b/content/arbitrage.md
@@ -4,6 +4,8 @@ Date: 2018-06-06 15:00
 Category: Blog
 Tags: finance, arbitrage
 Slug: arbitrage
+Lang: en
+Status: archive
 Summary: Here, we will give some detail on how to do real trading using arbitrage. There are always many ways to do so, and the method below is just one of them. But the key ideas are same. 
 
 This post is based on [High Frequency Trading and Probability Theory - Zhaodong Wang](https://scribd.com/document/346123211/High-Frequency-Trading-and-Probability-Theory-Zhaodong-Wang)

--- a/content/building-job-queue.md
+++ b/content/building-job-queue.md
@@ -1,9 +1,11 @@
-Title: Building job queue
+Title: Building a job queue
 Author: Nekrasov Pavel
 Date: 2021-10-01 15:00
 Category: Blog
 Tags: python, rabbitmq
 Slug: building-job-queue
+Lang: en
+Status: refresh
 Summary: In this article, we will build simple job queue on top of rabbitmq-server with aio-pika package.
 
 ## Abstract

--- a/content/business-it-solutions.md
+++ b/content/business-it-solutions.md
@@ -1,9 +1,11 @@
-Title: How to get well-developed IT solution
+Title: How to get a well-developed IT solution
 Author: Nekrasov Pavel
 Date: 2020-08-29 14:00
 Category: Blog
 Tags: science, markdown, template 
 Slug: business-it-solutions
+Lang: en
+Status: refresh
 Summary: In this note we try to understand how to: clarify requirements and determine the importance and urgency
 
 # How to get well-developed IT solution

--- a/content/candlestick-charts-plotly.md
+++ b/content/candlestick-charts-plotly.md
@@ -1,9 +1,11 @@
-Title: Stock market candlestick charts with plotly and python
+Title: Stock-market candlestick charts with Plotly and Python
 Author: Nekrasov Pavel
 Date: 2019-07-10 20:00
 Category: Blog
 Tags: python, notebook, finance, pandas, plotly
 Slug: candlestick-charts-plotly
+Lang: en
+Status: archive
 Summary: This article is the first of a short series on data analysis applied to finance, in which I’ll seek to demonstrate a few useful artifacts used by stock market professionals, data analysts and traders. The whole approach is done using Python.
 
 ## Candlesticks Interpretation

--- a/content/color-formatter.md
+++ b/content/color-formatter.md
@@ -4,6 +4,8 @@ Date: 2022-02-24 21:47
 Category: Blog
 Tags: python, logging
 Slug: color-formatter
+Lang: en
+Status: refresh
 Summary: This article explains how to get up and running with custom color fomatter in your logger.
 
 ## Contents

--- a/content/covid-dashboard.nbdata
+++ b/content/covid-dashboard.nbdata
@@ -1,7 +1,9 @@
-Title: Just another COVID-19 data visualisation
+Title: COVID-19 data visualization
 Author: Nekrasov Pavel
 Date: 2020-10-27 15:00
 Category: Blog
 Tags: python, notebook, pandas, wbdata
 Slug: covid-dashboard
+Lang: en
+Status: archive
 Summary: The goal of this notebook is to explore COVID-19 and World Bank API data

--- a/content/custom-logger.md
+++ b/content/custom-logger.md
@@ -4,6 +4,8 @@ Date: 2022-02-25 18:45
 Category: Blog
 Tags: python, logging
 Slug: custom-logger
+Lang: en
+Status: refresh
 Summary: The Python logging module may be used to build your own custom logger featuring special functionality according to your use case.
 
 ## Contents

--- a/content/deploying-a-static-website-to-bitbucket.md
+++ b/content/deploying-a-static-website-to-bitbucket.md
@@ -1,9 +1,11 @@
-Title: Deploying a static website to bitbucket
+Title: Deploying a static website to Bitbucket
 Author: Nekrasov Pavel
 Date: 2019-02-02 16:00
 Category: Blog
 Tags: python, markdown, pelican, bitbucket
 Slug: deploying-a-static-website-to-bitbucket
+Lang: en
+Status: deprecated
 Summary: We will use BitBucket for the task of hosting a small static website. The service is free and I already use BitBucket repositories to store the source code for my software projects so the workflow comes naturally.
 
 We will use BitBucket for the task of hosting a small static website.

--- a/content/devops-questions.md
+++ b/content/devops-questions.md
@@ -1,9 +1,11 @@
-Title: Obstacles to successful devops
+Title: Obstacles to successful DevOps
 Author: Nekrasov Pavel
 Date: 2021-04-09 10:00
 Category: Blog
 Tags: git, github, development, workflow
 Slug: devops-questions
+Lang: en
+Status: refresh
 Summary: In today’s enterprises, software is your company’s everyday face, whether through the desktop, the cloud, or a mobile device, to all parts of the globe.
 Software updates serve customer’s demands. Each one you deliver is your opportunity to renew -- or, if
 botched, destroy -- their trust. How can you make every update top-notch at top speed?

--- a/content/essay-paper-template.md
+++ b/content/essay-paper-template.md
@@ -1,9 +1,11 @@
-Title: Essay(simple paper) template
+Title: Essay template
 Author: Nekrasov Pavel
 Date: 2020-08-21 15:00
 Category: Blog
 Tags: science, markdown, template 
 Slug: essay-paper-template
+Lang: en
+Status: archive
 Summary: In this article template for essay(simple paper) is provided. There are useful markdown examples and source references.
 
 # Essay(simple paper) template

--- a/content/feature-engineering-on-ohlcv-candles-wit-xgboost.nbdata
+++ b/content/feature-engineering-on-ohlcv-candles-wit-xgboost.nbdata
@@ -1,9 +1,9 @@
-Title: Using XGBoost regressor on Indicators, ARIMA and FFT of ohlcv data
+Title: Use XGBoost on indicators, ARIMA, and FFT features from OHLCV data
 Author: Nekrasov Pavel
 Date: 2018-12-01 15:00
 Category: Blog
 Tags: python, notebook, finance, pandas, xgboost, arima, fft
 Slug: feature-engineering-on-ohlcv-candles-wit-xgboost
+Lang: en
+Status: archive
 Summary: The goal of this notebook is to apply XGBoost to set of features from ohlcv indicators, fft results and arima predictions to test feature importance.
-
-

--- a/content/fixing-caching-sha2-password.md
+++ b/content/fixing-caching-sha2-password.md
@@ -1,9 +1,11 @@
-Title: Authentication plugin 'caching_sha2_password' cannot be loaded
+Title: Authentication plugin caching_sha2_password cannot be loaded
 Author: Nekrasov Pavel
 Date: 2022-06-15 12:00
 Category: Blog
 Tags: mysql
 Slug: fixing-caching-sha2-password
+Lang: en
+Status: deprecated
 Summary: Fixing "Authentication plugin 'caching_sha2_password' cannot be loaded. The specific module can not be found" errors
 
 ## Contents

--- a/content/git-rebase.md
+++ b/content/git-rebase.md
@@ -1,9 +1,11 @@
-Title: How to rebase git branch
+Title: How to rebase a Git branch
 Author: Nekrasov Pavel
 Date: 2022-04-21 12:00
 Category: Blog
 Tags: git
 Slug: git-rebase
+Lang: en
+Status: keep
 Summary: Choosing between git rebase and git merge remains one of the most discussed topics in the community.
 
 ## Abstract

--- a/content/graphql-schema.md
+++ b/content/graphql-schema.md
@@ -1,9 +1,11 @@
-Title: Understand GraphQL Schema
+Title: Understand a GraphQL schema
 Author: Nekrasov Pavel
 Date: 2020-11-29 14:00
 Category: Blog
 Tags: graphql
 Slug: graphql-schema
+Lang: en
+Status: keep
 Summary: In this note, we will discuss what is a GraphQL schema and different ways to retrieve the GraphQL schema from a GraphQL server
 
 # Understand GraphQL Schema

--- a/content/install-nvm-node-yarn.md
+++ b/content/install-nvm-node-yarn.md
@@ -1,9 +1,11 @@
-Title: Install nvm, node and yarn for your Node.js application
+Title: Install NVM, Node, and Yarn
 Author: Nekrasov Pavel
 Date: 2022-01-11 15:00
 Category: Blog
 Tags: nvm, node, yarn
 Slug: install-nvm-node-yarn
+Lang: en
+Status: deprecated
 Summary: The official package manager for node is npm which comes pre-installed with node. We use npm to install yarn
 
 ## Abstract

--- a/content/install-pelican-and-create-project-skeleton.md
+++ b/content/install-pelican-and-create-project-skeleton.md
@@ -1,9 +1,11 @@
-Title: Install Pelican and create project skeleton
+Title: Install Pelican and create a project skeleton
 Author: Nekrasov Pavel
 Date: 2019-02-01 16:00
 Category: Blog
 Tags: python, markdown, pelican
 Slug: install-pelican-and-create-project-skeleton
+Lang: en
+Status: deprecated
 Summary: Building your own static website has several advantages over a traditional website that uses a database to store content. Static websites are faster because pages are rendered in advance and deliver the same content to all visitors. They are cheaper to host and are more secure since the website has no database.
 
 Building your own static website has several advantages over a traditional website that uses a database to store content. 

--- a/content/linux-change-swap-size.md
+++ b/content/linux-change-swap-size.md
@@ -4,6 +4,8 @@ Date: 2022-08-06 15:00
 Category: Blog
 Tags: linux
 Slug: linux-change-swap-size
+Lang: en
+Status: keep
 Summary: If you want to change the size of your swap file just follow the following steps.
 
 ## Change swap size in Ubuntu

--- a/content/linux-list-users.md
+++ b/content/linux-list-users.md
@@ -1,9 +1,11 @@
-Title: How to List Users in Linux
+Title: How to list users in Linux
 Author: Nekrasov Pavel
 Date: 2022-08-07 15:00
 Category: Blog
 Tags: linux
 Slug: linux-list-users
+Lang: en
+Status: keep
 Summary: This article will show you how to list users in Linux systems.
 
 ## Abstract

--- a/content/linux-port.md
+++ b/content/linux-port.md
@@ -1,9 +1,11 @@
-Title: Ways to find out which process is listening on a specific port
+Title: Find which process is listening on a specific port
 Author: Nekrasov Pavel
 Date: 2022-03-16 15:00
 Category: Blog
 Tags: linux
 Slug: linux-port
+Lang: en
+Status: keep
 Summary: In this article, we will show three different ways to find the process listening on a specific port in Linux.
 
 ## Abstract

--- a/content/markov-chain-bean-machine.nbdata
+++ b/content/markov-chain-bean-machine.nbdata
@@ -4,4 +4,6 @@ Date: 2020-01-25 15:00
 Category: Blog
 Tags: python, numpy, scipy, matplotlib
 Slug: markov-chain-bean-machine
+Lang: en
+Status: archive
 Summary: We will use the stationary distribution of an absorbing markov chain to simulate a Galton board.

--- a/content/mkrf-spb-geo-data.nbdata
+++ b/content/mkrf-spb-geo-data.nbdata
@@ -1,7 +1,9 @@
-Title: Визуализации картографических данных в Jupyter notebook
+Title: Визуализация картографических данных в Jupyter Notebook
 Author: Nekrasov Pavel
 Date: 2021-04-04 15:00
 Category: Blog
 Tags: python, leaflet, notebook, pandas
 Slug: mkrf-spb-geo-data
+Lang: ru
+Status: archive
 Summary: В этой статье, мы углубимся в изучение Jupyter Interactive Widgets и Ipyleaflet package, для визуализации картографических данных в Jupyter notebook.

--- a/content/mysql-server-errors.md
+++ b/content/mysql-server-errors.md
@@ -4,6 +4,8 @@ Date: 2023-07-11 13:00
 Category: Blog
 Tags: mysql, linux
 Slug: mysql-server-errors
+Lang: en
+Status: keep
 Summary: This post is about errors after "The MySQL server has gone away", which means that the MySQL server (mysqld) timed out and closed the connection.
 
 ## Abstract

--- a/content/openssl-ubuntu.md
+++ b/content/openssl-ubuntu.md
@@ -4,6 +4,8 @@ Date: 2019-02-05 15:00
 Category: Blog
 Tags: linux, ubuntu, openssl
 Slug: upgrading-openssl-ubuntu
+Lang: en
+Status: deprecated
 Summary: To avoid openssl and TLS version issue we will update openSSL on server and desktop version of Ubuntu 18.0. We will download it manually, install and make necessary file permission changes.
 
 To avoid openssl and TLS version issue we will update openSSL on server and desktop version of Ubuntu 18.04

--- a/content/pascals-triangle.nbdata
+++ b/content/pascals-triangle.nbdata
@@ -4,4 +4,6 @@ Date: 2020-08-01 15:00
 Category: Blog
 Tags: python, math, matplotlib, networkx, pydot
 Slug: pascals-triangle
+Lang: en
+Status: archive
 Summary: In this notebook we will build and visualise Pascal's Triangle with networkx and pydot

--- a/content/pelican-github-script-automation.md
+++ b/content/pelican-github-script-automation.md
@@ -1,9 +1,11 @@
-Title: Move blog to github and automate deploying with git hooks
+Title: Move a blog to GitHub and automate deployment with Git hooks
 Author: Nekrasov Pavel
 Date: 2020-08-22 20:00
 Category: Blog
 Tags: pelican, git, github
 Slug: pelican-github-script-automation
+Lang: en
+Status: deprecated
 Summary: In this post we will describe how to move your blog to github and automate git hooks tho update gh-pages branch on commits
 
 This blog is powered by [Pelican](http://docs.getpelican.com/en/stable) and hosted through 

--- a/content/publishing-articles-workflow.md
+++ b/content/publishing-articles-workflow.md
@@ -4,6 +4,8 @@ Date: 2020-09-09 15:00
 Category: Blog
 Tags: markdown, notebook, workflow
 Slug: publishing-articles-workflow
+Lang: en
+Status: archive
 Summary: In this article, I would like to document my blogging experience. After writing and distributing articles for a long time, I kind of set up a framework when it comes to distributing articles.
 
 ## Abstract

--- a/content/python-gil.md
+++ b/content/python-gil.md
@@ -1,9 +1,11 @@
-Title: Why you need Python Global Interpreter Lock and how it works
+Title: Why Python needs the Global Interpreter Lock and how it works
 Author: Nekrasov Pavel
 Date: 2022-03-20 15:00
 Category: Blog
 Tags: python, gil, threading, multiprocessing
 Slug: python-gil
+Lang: en
+Status: keep
 Summary: In this article we will discuss how the GIL impacts application performance and how that impact can be mitigated.
 
 ## Abstract

--- a/content/python-object-reference.md
+++ b/content/python-object-reference.md
@@ -4,6 +4,8 @@ Date: 2022-07-20 12:00
 Category: Blog
 Tags: python
 Slug: python-object-reference
+Lang: en
+Status: keep
 Summary: This post is about how python treats object assignment and some of the hidden gotcha’s that can cause unintended errors along the way.
 
 ## Abstract

--- a/content/python-poetry-docker.md
+++ b/content/python-poetry-docker.md
@@ -1,9 +1,11 @@
-Title: Python app with poetry & docker
+Title: Python app with Poetry and Docker
 Author: Nekrasov Pavel
 Date: 2023-02-20 12:00
 Category: Blog
 Tags: python, poetry, development
 Slug: python-poetry-docker
+Lang: en
+Status: keep
 Summary: This post is about building multi-stage docker image with python app and poetry.
 
 ## Abstract

--- a/content/setting-up-gitlab-ci.md
+++ b/content/setting-up-gitlab-ci.md
@@ -1,9 +1,11 @@
-Title: Setting Up GitLab CI for a Python Application
+Title: Setting up GitLab CI for a Python application
 Author: Nekrasov Pavel
 Date: 2021-07-10 15:00
 Category: Blog
 Tags: gitlab, python, mypy, pytest, flake8, pylint
 Slug: setting-up-gitlab-ci
+Lang: en
+Status: refresh
 Summary: This article describes how to configure a Continuous Integration (CI) process on GitLab for a python application. This article utilizes one of my python applications to show how to setup the CI process.
 
 ## Contents

--- a/content/setting-up-nginx-gunicorn-flask.md
+++ b/content/setting-up-nginx-gunicorn-flask.md
@@ -1,9 +1,11 @@
-Title: Setting Up Nginx, Gunicorn for Flask app 
+Title: Setting up Nginx and Gunicorn for a Flask application
 Author: Nekrasov Pavel
 Date: 2021-11-03 15:00
 Category: Blog
 Tags: nginx, gunicorn, flask, python
 Slug: setting-up-nginx-gunicorn-flask
+Lang: en
+Status: deprecated
 Summary: This article describes how to configure a Nginx and gunicorn to run Flask app.
 
 ## Abstract

--- a/content/share-data.md
+++ b/content/share-data.md
@@ -4,6 +4,8 @@ Date: 2020-09-29 14:00
 Category: Blog
 Tags: data, workflow
 Slug: share-data
+Lang: en
+Status: archive
 Summary: This is a guide for anyone who needs to share data with a statistician or data scientist.
 
 Initial article was writen by [Jeff Leek](http://biostat.jhsph.edu/~jleek/)

--- a/content/shell-capture.md
+++ b/content/shell-capture.md
@@ -1,9 +1,11 @@
-Title: Capturing shell output in python
+Title: Capturing shell output in Python
 Author: Nekrasov Pavel
 Date: 2022-03-26 12:00
 Category: Blog
 Tags: linux, python, shell
 Slug: shell-capture
+Lang: en
+Status: keep
 Summary: In this article we will use python subprocess to run shell comand and capture its output.
 
 ## Abstract

--- a/content/stock-perfomance-analysis.nbdata
+++ b/content/stock-perfomance-analysis.nbdata
@@ -1,8 +1,9 @@
-Title: Stock performance analysis using python Financial Functions
+Title: Stock-performance analysis using Python Financial Functions
 Author: Nekrasov Pavel
 Date: 2019-07-11 15:00
 Category: Blog
 Tags: python, notebook, finance, ffn, matplotlib
 Slug: stock-perfomance-analysis
+Lang: en
+Status: archive
 Summary: Continuing  short series on data analysis applied to finance, this article is a step further into exploring Python’s many functionalities towards stock market diagnosis.
-

--- a/content/technical-debt-examples.md
+++ b/content/technical-debt-examples.md
@@ -4,6 +4,8 @@ Date: 2023-10-14 15:00
 Category: Blog
 Tags: development, science, workflow
 Slug: technical-debt-examples
+Lang: ru
+Status: refresh
 Summary: В этом посте я хочу более подробно рассмотреть примеры технического долга в существующем коде.
 
 # Примеры технического долга

--- a/content/update-django-user-password.md
+++ b/content/update-django-user-password.md
@@ -4,6 +4,8 @@ Date: 2023-09-02 15:00
 Category: Blog
 Tags: python, django
 Slug: update-django-user-password
+Lang: en
+Status: keep
 Summary: Update Django user password from shell.
 
 ## Update Django user password from shell

--- a/content/vscode-black-isort.md
+++ b/content/vscode-black-isort.md
@@ -4,6 +4,8 @@ Date: 2022-05-10 12:00
 Category: Blog
 Tags: python, vscode, black
 Slug: python-black-isort
+Lang: en
+Status: keep
 Summary: How to use Black to format python code, and organise imports on save.
 
 How to use Black to format Python code, and organise imports on save in VSCode.

--- a/content/what-is-technical-debt.md
+++ b/content/what-is-technical-debt.md
@@ -4,6 +4,8 @@ Date: 2023-09-16 15:00
 Category: Blog
 Tags: development, science, workflow
 Slug: what-is-technical-debt
+Lang: ru
+Status: refresh
 Summary: Что такое технический долг? Примеры, профилактика и лучшие практики
 
 # Что такое технический долг? Примеры, профилактика и лучшие практики

--- a/migration/__init__.py
+++ b/migration/__init__.py
@@ -1,0 +1,1 @@
+"""Migration validation packages for the site source repository."""

--- a/migration/site002v/README.md
+++ b/migration/site002v/README.md
@@ -14,7 +14,8 @@ uv sync --locked --all-groups
 ./scripts/site validate
 ./scripts/site test
 uv run --locked --all-groups ruff check \
-  migration/site_build migration/site002v/validate.py
+  migration/site_build migration/site002v/validate.py migration/site003 \
+  plugins/site_metadata.py
 ```
 
 `validate` creates a separate locked environment under a temporary work root,
@@ -35,7 +36,7 @@ The build subprocess is instrumented to fail on kernel starts, calls to
 compares every content-source hash and the Git status before and after both
 builds.
 
-Five negative cases use isolated fixture copies under the temporary work root;
+Seven negative cases use isolated fixture copies under the temporary work root;
 they never edit `content/`:
 
 - missing expected source;
@@ -43,17 +44,28 @@ they never edit `content/`:
 - missing adjacent `.nbdata`;
 - missing required `Title` metadata;
 - malformed notebook JSON.
+- unknown SITE-003 lifecycle status;
+- invalid SITE-003 language.
 
 Every case must exit non-zero with its source path, reader stage, stable error
 category, and cause type.
 
-## Accepted historical deviations
+## SITE-003 metadata resolution
 
-SITE-002V gates but does not repair these PLUGIN-003 observations:
+SITE-003 resolves the accepted PLUGIN-003 metadata observations while reusing
+this validator:
 
-- 8 of 11 route-inventory titles differ from reader titles;
-- reader language is absent for 11 of 11 notebooks;
-- rendered language differs from the target for 1 of 11 notebooks;
+- route-inventory versus reader notebook title mismatches: 8 to 0;
+- absent reader language: 11 to 0;
+- rendered language versus target mismatches: 1 to 0.
+
+The frozen BASE-001 metadata file is not edited. The validator derives a
+temporary manifest-authoritative title overlay and requires exactly 28 legacy
+page-title updates, including the 8 notebook corrections, before running the
+existing publication gate.
+
+The remaining accepted accessibility observations are unchanged:
+
 - nbconvert emits 57 generated fallback image alts across nine sources;
 - two authored image alts are empty.
 
@@ -62,9 +74,8 @@ Pelican's console log may deduplicate identical nbconvert records; its emitted
 ledger is gated separately for deterministic counts and rejects every warning
 type outside the two accepted alt categories.
 
-Title/language remediation belongs to SITE-003. Accessibility remediation and
-human original-zoom review belong to later theme/accessibility work. No warning
-outside this exact ledger is accepted.
+Accessibility remediation and human original-zoom review belong to later
+theme/accessibility work. No warning outside this exact ledger is accepted.
 
 The former vendored reader is preserved only under
 `migration/site002v/archive/legacy-ipynb-reader/`; it is outside active
@@ -74,8 +85,6 @@ The former vendored reader is preserved only under
 
 The BASE-001 checker implementation and its six negative/positive unit tests
 remain green. Running the complete frozen production checker against this
-source-branch artifact still reports 41 known pre-cutover differences: modern
-pages and six newer resources that exist only on `gh-pages`, modern theme/home
-metadata, feed identity/count differences, redirects/assets, and the language
-gaps assigned to SITE-003. SITE-002V does not weaken that checker or treat the
+source-branch artifact still reports its known pre-cutover production/theme/feed
+differences. SITE-002V and SITE-003 do not weaken that checker or treat the
 source branch as deployable; later convergence tasks own those differences.

--- a/migration/site002v/evidence/validation.json
+++ b/migration/site002v/evidence/validation.json
@@ -1,5 +1,5 @@
 {
-  "contract": "nekrasovp-site002v-validation.v1",
+  "contract": "nekrasovp-site002v-validation.v2",
   "counts": {
     "articles": 46,
     "markdown": 35,
@@ -19,7 +19,7 @@
     "plugin_commit": "137e1eb0ea620f1b15fff0ba81725eea23de1b7a"
   },
   "determinism": {
-    "normalized_publication_evidence_sha256": "49f128cc08aaac57ad5c2d2b42a7911a6a99838cd698e2f7c715af1e5de38d18",
+    "normalized_publication_evidence_sha256": "f13343b164247f5e205fe058733b779a55bfb4de81561bcff5dc49ddf1c45f6d",
     "publication_evidence_identical": true,
     "warning_ledgers_identical": true
   },
@@ -29,35 +29,22 @@
     "warning_records": 8
   },
   "metadata_observations": {
-    "inventory_reader_title_mismatches": [
-      "Number-sequences.ipynb",
-      "Stock-market-portfolio-optimisation.ipynb",
-      "Testing-hypothesis-on-football-data-set.ipynb",
-      "Use Cython to speed up your Python code.ipynb",
-      "covid-dashboard.ipynb",
-      "feature-engineering-on-ohlcv-candles-wit-xgboost.ipynb",
-      "mkrf-spb-geo-data.ipynb",
-      "stock-perfomance-analysis.ipynb"
-    ],
+    "inventory_reader_title_mismatches": [],
     "owner": "SITE-003",
-    "reader_language_absent": [
-      "Getting-stock-data-with-pandas-datareader.ipynb",
-      "Number-sequences.ipynb",
-      "Stock-market-portfolio-optimisation.ipynb",
-      "Testing-hypothesis-on-football-data-set.ipynb",
-      "Use Cython to speed up your Python code.ipynb",
-      "covid-dashboard.ipynb",
-      "feature-engineering-on-ohlcv-candles-wit-xgboost.ipynb",
-      "markov-chain-bean-machine.ipynb",
-      "mkrf-spb-geo-data.ipynb",
-      "pascals-triangle.ipynb",
-      "stock-perfomance-analysis.ipynb"
-    ],
-    "rendered_language_target_mismatches": [
-      "mkrf-spb-geo-data.ipynb"
-    ]
+    "reader_language_absent": [],
+    "rendered_language_target_mismatches": []
   },
   "negative_gates": {
+    "invalid_language": {
+      "exit_code": 1,
+      "isolated_fixture": true,
+      "source": "technical-debt-examples.md",
+      "tokens": [
+        "inventory_validation",
+        "invalid_language",
+        "InvalidLanguage"
+      ]
+    },
     "malformed_notebook": {
       "exit_code": 1,
       "isolated_fixture": true,
@@ -105,6 +92,16 @@
         "publication_verification",
         "missing_expected_source",
         "MissingExpectedSource"
+      ]
+    },
+    "unknown_status": {
+      "exit_code": 1,
+      "isolated_fixture": true,
+      "source": "technical-debt-examples.md",
+      "tokens": [
+        "inventory_validation",
+        "unknown_status",
+        "UnknownStatus"
       ]
     }
   },
@@ -285,9 +282,9 @@
     {
       "baseline_metadata": {
         "language": "en",
-        "page_title": "Just another COVID-19 data visualisation - Data driven"
+        "page_title": "COVID-19 data visualization - Data driven"
       },
-      "content_class_sha256": "c321e97238b0065495767ea87ced42338e0e512a687d1d360ea98c5aeed66021",
+      "content_class_sha256": "a54a5595a88c8ce90c087250e639e206dd5961ac004c4da3ffbf686a3bfbb5f5",
       "content_modes": [
         "code",
         "image",
@@ -298,7 +295,7 @@
       "metadata": {
         "category": "Blog",
         "date": "2020-10-27",
-        "language": null,
+        "language": "en",
         "summary": "The goal of this notebook is to explore COVID-19 and World Bank API data",
         "tags": [
           "python",
@@ -306,7 +303,7 @@
           "pandas",
           "wbdata"
         ],
-        "title": "Just another COVID-19 data visualisation"
+        "title": "COVID-19 data visualization"
       },
       "publisher_target": {
         "language": "en",
@@ -314,7 +311,7 @@
       },
       "rendered_observation": {
         "html_lang": "en",
-        "page_title": "Just another COVID-19 data visualisation - Data driven"
+        "page_title": "COVID-19 data visualization - Data driven"
       },
       "route": "/covid-dashboard.html",
       "source": "covid-dashboard.ipynb",
@@ -344,9 +341,9 @@
     {
       "baseline_metadata": {
         "language": "en",
-        "page_title": "Using XGBoost regressor on Indicators, ARIMA and FFT of ohlcv data - Data driven"
+        "page_title": "Use XGBoost on indicators, ARIMA, and FFT features from OHLCV data - Data driven"
       },
-      "content_class_sha256": "5baeb77b86d88841eab210554a5ba4df4b13e5e3a7bcc1325588a8aac0d05e7f",
+      "content_class_sha256": "c16faac6d9170e93e573debae65a29dda9298c4513ae8c4f1185bdbb0ab87981",
       "content_modes": [
         "code",
         "image",
@@ -356,7 +353,7 @@
       "metadata": {
         "category": "Blog",
         "date": "2018-12-01",
-        "language": null,
+        "language": "en",
         "summary": "The goal of this notebook is to apply XGBoost to set of features from ohlcv indicators, fft results and arima predictions to test feature importance.",
         "tags": [
           "python",
@@ -367,7 +364,7 @@
           "arima",
           "fft"
         ],
-        "title": "Using XGBoost regressor on Indicators, ARIMA and FFT of ohlcv data"
+        "title": "Use XGBoost on indicators, ARIMA, and FFT features from OHLCV data"
       },
       "publisher_target": {
         "language": "en",
@@ -375,7 +372,7 @@
       },
       "rendered_observation": {
         "html_lang": "en",
-        "page_title": "Using XGBoost regressor on Indicators, ARIMA and FFT of ohlcv data - Data driven"
+        "page_title": "Use XGBoost on indicators, ARIMA, and FFT features from OHLCV data - Data driven"
       },
       "route": "/feature-engineering-on-ohlcv-candles-wit-xgboost.html",
       "source": "feature-engineering-on-ohlcv-candles-wit-xgboost.ipynb",
@@ -427,7 +424,7 @@
         "language": "en",
         "page_title": "Simulating a Galton board with Markov chains - Data driven"
       },
-      "content_class_sha256": "f713336df1ce60889b6e31d9afd8a6c25464e079916722b0a0cf297fc3abb84c",
+      "content_class_sha256": "21c33a13ee32446bec0b0f5be345c664de6653ac21e216e325c5a431a2fae979",
       "content_modes": [
         "code",
         "image",
@@ -437,7 +434,7 @@
       "metadata": {
         "category": "Blog",
         "date": "2020-01-25",
-        "language": null,
+        "language": "en",
         "summary": "We will use the stationary distribution of an absorbing markov chain to simulate a Galton board.",
         "tags": [
           "python",
@@ -463,9 +460,9 @@
     {
       "baseline_metadata": {
         "language": "ru",
-        "page_title": "Визуализации картографических данных в Jupyter notebook - Data driven"
+        "page_title": "Визуализация картографических данных в Jupyter Notebook - Data driven"
       },
-      "content_class_sha256": "2bab522bd75d2678ad3d4f4a86583950a7cf0ea803789f5e49e35647b7ff3370",
+      "content_class_sha256": "fe4a6bb0779dcff010e3c989b3efcd68306935386ee83ecd928e9355ac38a912",
       "content_modes": [
         "code",
         "markdown"
@@ -473,7 +470,7 @@
       "metadata": {
         "category": "Blog",
         "date": "2021-04-04",
-        "language": null,
+        "language": "ru",
         "summary": "В этой статье, мы углубимся в изучение Jupyter Interactive Widgets и Ipyleaflet package, для визуализации картографических данных в Jupyter notebook.",
         "tags": [
           "python",
@@ -481,15 +478,15 @@
           "notebook",
           "pandas"
         ],
-        "title": "Визуализации картографических данных в Jupyter notebook"
+        "title": "Визуализация картографических данных в Jupyter Notebook"
       },
       "publisher_target": {
         "language": "ru",
         "route_inventory_title": "Визуализация картографических данных в Jupyter Notebook"
       },
       "rendered_observation": {
-        "html_lang": "en",
-        "page_title": "Визуализации картографических данных в Jupyter notebook - Data driven"
+        "html_lang": "ru",
+        "page_title": "Визуализация картографических данных в Jupyter Notebook - Data driven"
       },
       "route": "/mkrf-spb-geo-data.html",
       "source": "mkrf-spb-geo-data.ipynb",
@@ -504,9 +501,9 @@
     {
       "baseline_metadata": {
         "language": "en",
-        "page_title": "Number sequences visualisation with python - Data driven"
+        "page_title": "Number-sequence visualization with Python - Data driven"
       },
-      "content_class_sha256": "8b14d3d572b98f6905edca3c12e6ecfac2e7b470aec1490f3ea951865960cdcc",
+      "content_class_sha256": "09049d751c8b74caee0bab75ce713373b39162b2653d35ff41b82e84596a61d2",
       "content_modes": [
         "code",
         "image",
@@ -516,14 +513,14 @@
       "metadata": {
         "category": "Blog",
         "date": "2019-08-29",
-        "language": null,
+        "language": "en",
         "summary": "In this notebook we will compute and visualise some famous and nice looking number sequences.",
         "tags": [
           "python",
           "notebook",
           "numpy"
         ],
-        "title": "Number sequences visualisation with python"
+        "title": "Number-sequence visualization with Python"
       },
       "publisher_target": {
         "language": "en",
@@ -531,7 +528,7 @@
       },
       "rendered_observation": {
         "html_lang": "en",
-        "page_title": "Number sequences visualisation with python - Data driven"
+        "page_title": "Number-sequence visualization with Python - Data driven"
       },
       "route": "/number-sequences.html",
       "source": "Number-sequences.ipynb",
@@ -543,7 +540,7 @@
         "language": "en",
         "page_title": "Pascal's Triangle - Data driven"
       },
-      "content_class_sha256": "f4ce963ab0e85298639befdd47ac7e3eccb06805456b786d55308eec2bbdbcfa",
+      "content_class_sha256": "2bb2ffc5b2a906374a1d4da9100d9ed7d1ce09a98bf098759ece338b21ae3b19",
       "content_modes": [
         "code",
         "image",
@@ -553,7 +550,7 @@
       "metadata": {
         "category": "Blog",
         "date": "2020-08-01",
-        "language": null,
+        "language": "en",
         "summary": "In this notebook we will build and visualise Pascal's Triangle with networkx and pydot",
         "tags": [
           "python",
@@ -637,7 +634,7 @@
         "language": "en",
         "page_title": "Getting stock data with pandas-datareader - Data driven"
       },
-      "content_class_sha256": "dc7a080c64afbeeb70222b21eacbcfd1d945d54c6063bd87c435638ab3726bb9",
+      "content_class_sha256": "1a1d5fa049c31fdec0efb6b2e4f78bdae24f6fa05bda6bd864c3c719707c81ac",
       "content_modes": [
         "code",
         "image",
@@ -648,7 +645,7 @@
       "metadata": {
         "category": "Blog",
         "date": "2019-03-01",
-        "language": null,
+        "language": "en",
         "summary": "The goal of this article is to provide an easy introduction to stock market analysis using Python. In this notebook we will use pandas_datareader module. We will walk through a simple Python script to retrieve, analyze, and visualize data from different markets.",
         "tags": [
           "python",
@@ -674,9 +671,9 @@
     {
       "baseline_metadata": {
         "language": "en",
-        "page_title": "Stock market portfolio optimisation - Data driven"
+        "page_title": "Stock-market portfolio optimization - Data driven"
       },
-      "content_class_sha256": "91dc46be61d8434c72f32cdee24636ac52dc26c3ccdd53b29687fd695ef807a6",
+      "content_class_sha256": "8a9ba2144250a8fae04b4b86e76da308e98f09daa8626200626f1364bce04844",
       "content_modes": [
         "code",
         "image",
@@ -687,7 +684,7 @@
       "metadata": {
         "category": "Blog",
         "date": "2019-07-12",
-        "language": null,
+        "language": "en",
         "summary": "The goal of this notebook is to provide an introduction to stock market portfolio optimisation using Python.",
         "tags": [
           "python",
@@ -696,7 +693,7 @@
           "pandas",
           "portfolio"
         ],
-        "title": "Stock market portfolio optimisation"
+        "title": "Stock-market portfolio optimization"
       },
       "publisher_target": {
         "language": "en",
@@ -704,7 +701,7 @@
       },
       "rendered_observation": {
         "html_lang": "en",
-        "page_title": "Stock market portfolio optimisation - Data driven"
+        "page_title": "Stock-market portfolio optimization - Data driven"
       },
       "route": "/stock-market-portfolio-optimisation.html",
       "source": "Stock-market-portfolio-optimisation.ipynb",
@@ -714,9 +711,9 @@
     {
       "baseline_metadata": {
         "language": "en",
-        "page_title": "Stock performance analysis using python Financial Functions - Data driven"
+        "page_title": "Stock-performance analysis using Python Financial Functions - Data driven"
       },
-      "content_class_sha256": "cb69f556a5df167b11d3876cf5c6037b1b01883631927a052a1ac5aa915fc930",
+      "content_class_sha256": "9e7d77439fe20d5be9e7eb1d227240101dcf4c9b8456da0d85d1bd0fca105dab",
       "content_modes": [
         "code",
         "image",
@@ -727,7 +724,7 @@
       "metadata": {
         "category": "Blog",
         "date": "2019-07-11",
-        "language": null,
+        "language": "en",
         "summary": "Continuing short series on data analysis applied to finance, this article is a step further into exploring Python’s many functionalities towards stock market diagnosis.",
         "tags": [
           "python",
@@ -736,7 +733,7 @@
           "ffn",
           "matplotlib"
         ],
-        "title": "Stock performance analysis using python Financial Functions"
+        "title": "Stock-performance analysis using Python Financial Functions"
       },
       "publisher_target": {
         "language": "en",
@@ -744,7 +741,7 @@
       },
       "rendered_observation": {
         "html_lang": "en",
-        "page_title": "Stock performance analysis using python Financial Functions - Data driven"
+        "page_title": "Stock-performance analysis using Python Financial Functions - Data driven"
       },
       "route": "/stock-perfomance-analysis.html",
       "source": "stock-perfomance-analysis.ipynb",
@@ -759,9 +756,9 @@
     {
       "baseline_metadata": {
         "language": "en",
-        "page_title": "Testing hypothesis on football data-set from kaggle - Data driven"
+        "page_title": "Testing a hypothesis on a football data set from Kaggle - Data driven"
       },
-      "content_class_sha256": "4c52d966699b3838f3568c402a603cabf96503d7b76418a4ae67b023da580607",
+      "content_class_sha256": "8b722cafe93ddce4b908b0366cb14e72345a9ae181b0b5e18d8a2fa8057b42c7",
       "content_modes": [
         "code",
         "image",
@@ -772,7 +769,7 @@
       "metadata": {
         "category": "Blog",
         "date": "2019-05-10",
-        "language": null,
+        "language": "en",
         "summary": "In this notebook we will use the data-set, International football results from 1872 to 2019. We will try ANOVA hypothesis testing technique.",
         "tags": [
           "python",
@@ -784,7 +781,7 @@
           "matplotlib",
           "ANOVA"
         ],
-        "title": "Testing hypothesis on football data-set from kaggle"
+        "title": "Testing a hypothesis on a football data set from Kaggle"
       },
       "publisher_target": {
         "language": "en",
@@ -792,7 +789,7 @@
       },
       "rendered_observation": {
         "html_lang": "en",
-        "page_title": "Testing hypothesis on football data-set from kaggle - Data driven"
+        "page_title": "Testing a hypothesis on a football data set from Kaggle - Data driven"
       },
       "route": "/testing-hypothesis-on-football-data-set.html",
       "source": "Testing-hypothesis-on-football-data-set.ipynb",
@@ -812,9 +809,9 @@
     {
       "baseline_metadata": {
         "language": "en",
-        "page_title": "Use Cython to speed up your Python code - Data driven"
+        "page_title": "Use Cython to speed up Python code - Data driven"
       },
-      "content_class_sha256": "c8ef403e744c8481c16c662324cfe27ffbdc1d8d5515307a206e0b3728ad958f",
+      "content_class_sha256": "f383afdac3cc9a36d27599e8b7b1b1825c6b6f1e58acad5e3df9177874d4b611",
       "content_modes": [
         "code",
         "markdown"
@@ -822,13 +819,13 @@
       "metadata": {
         "category": "Blog",
         "date": "2019-09-02",
-        "language": null,
+        "language": "en",
         "summary": "In this notebook will try to convert pure Python code to Cython and test speed up with magic functions.",
         "tags": [
           "python",
           "cython"
         ],
-        "title": "Use Cython to speed up your Python code"
+        "title": "Use Cython to speed up Python code"
       },
       "publisher_target": {
         "language": "en",
@@ -836,7 +833,7 @@
       },
       "rendered_observation": {
         "html_lang": "en",
-        "page_title": "Use Cython to speed up your Python code - Data driven"
+        "page_title": "Use Cython to speed up Python code - Data driven"
       },
       "route": "/use-cython-to-speedup-your-python-code.html",
       "source": "Use Cython to speed up your Python code.ipynb",
@@ -862,6 +859,265 @@
       "representative-rich-output"
     ],
     "title": "SITE-002V representative committed outputs"
+  },
+  "site003": {
+    "baseline_overlay": {
+      "frozen_baseline_sha256": "b209396e3d2926af6cdf69e8feab3afa1adec2fbadc13517866e3f3d2ecec653",
+      "overlay_sha256": "fcd3384160992071eaa81bd1a3d509eaeac071bf48f8cb9b7bf6c09a2445abe9",
+      "title_overrides": [
+        {
+          "after": "Python app with Poetry and Docker - Data driven",
+          "before": "Python app with poetry & docker - Data driven",
+          "route": "/python-poetry-docker.html",
+          "source": "python-poetry-docker.md"
+        },
+        {
+          "after": "How to list users in Linux - Data driven",
+          "before": "How to List Users in Linux - Data driven",
+          "route": "/linux-list-users.html",
+          "source": "linux-list-users.md"
+        },
+        {
+          "after": "Authentication plugin caching_sha2_password cannot be loaded - Data driven",
+          "before": "Authentication plugin 'caching_sha2_password' cannot be loaded - Data driven",
+          "route": "/fixing-caching-sha2-password.html",
+          "source": "fixing-caching-sha2-password.md"
+        },
+        {
+          "after": "How to rebase a Git branch - Data driven",
+          "before": "How to rebase git branch - Data driven",
+          "route": "/git-rebase.html",
+          "source": "git-rebase.md"
+        },
+        {
+          "after": "Capturing shell output in Python - Data driven",
+          "before": "Capturing shell output in python - Data driven",
+          "route": "/shell-capture.html",
+          "source": "shell-capture.md"
+        },
+        {
+          "after": "Why Python needs the Global Interpreter Lock and how it works - Data driven",
+          "before": "Why you need Python Global Interpreter Lock and how it works - Data driven",
+          "route": "/python-gil.html",
+          "source": "python-gil.md"
+        },
+        {
+          "after": "Find which process is listening on a specific port - Data driven",
+          "before": "Ways to find out which process is listening on a specific port - Data driven",
+          "route": "/linux-port.html",
+          "source": "linux-port.md"
+        },
+        {
+          "after": "Install NVM, Node, and Yarn - Data driven",
+          "before": "Install nvm, node and yarn for your Node.js application - Data driven",
+          "route": "/install-nvm-node-yarn.html",
+          "source": "install-nvm-node-yarn.md"
+        },
+        {
+          "after": "Setting up Nginx and Gunicorn for a Flask application - Data driven",
+          "before": "Setting Up Nginx, Gunicorn for Flask app - Data driven",
+          "route": "/setting-up-nginx-gunicorn-flask.html",
+          "source": "setting-up-nginx-gunicorn-flask.md"
+        },
+        {
+          "after": "Building a job queue - Data driven",
+          "before": "Building job queue - Data driven",
+          "route": "/building-job-queue.html",
+          "source": "building-job-queue.md"
+        },
+        {
+          "after": "Setting up GitLab CI for a Python application - Data driven",
+          "before": "Setting Up GitLab CI for a Python Application - Data driven",
+          "route": "/setting-up-gitlab-ci.html",
+          "source": "setting-up-gitlab-ci.md"
+        },
+        {
+          "after": "Obstacles to successful DevOps - Data driven",
+          "before": "Obstacles to successful devops - Data driven",
+          "route": "/devops-questions.html",
+          "source": "devops-questions.md"
+        },
+        {
+          "after": "Визуализация картографических данных в Jupyter Notebook - Data driven",
+          "before": "Визуализации картографических данных в Jupyter notebook - Data driven",
+          "route": "/mkrf-spb-geo-data.html",
+          "source": "mkrf-spb-geo-data.ipynb"
+        },
+        {
+          "after": "Understand a GraphQL schema - Data driven",
+          "before": "Understand GraphQL Schema - Data driven",
+          "route": "/graphql-schema.html",
+          "source": "graphql-schema.md"
+        },
+        {
+          "after": "COVID-19 data visualization - Data driven",
+          "before": "Just another COVID-19 data visualisation - Data driven",
+          "route": "/covid-dashboard.html",
+          "source": "covid-dashboard.ipynb"
+        },
+        {
+          "after": "How to get a well-developed IT solution - Data driven",
+          "before": "How to get well-developed IT solution - Data driven",
+          "route": "/business-it-solutions.html",
+          "source": "business-it-solutions.md"
+        },
+        {
+          "after": "Move a blog to GitHub and automate deployment with Git hooks - Data driven",
+          "before": "Move blog to github and automate deploying with git hooks - Data driven",
+          "route": "/pelican-github-script-automation.html",
+          "source": "pelican-github-script-automation.md"
+        },
+        {
+          "after": "Essay template - Data driven",
+          "before": "Essay(simple paper) template - Data driven",
+          "route": "/essay-paper-template.html",
+          "source": "essay-paper-template.md"
+        },
+        {
+          "after": "Use Cython to speed up Python code - Data driven",
+          "before": "Use Cython to speed up your Python code - Data driven",
+          "route": "/use-cython-to-speedup-your-python-code.html",
+          "source": "Use Cython to speed up your Python code.ipynb"
+        },
+        {
+          "after": "Number-sequence visualization with Python - Data driven",
+          "before": "Number sequences visualisation with python - Data driven",
+          "route": "/number-sequences.html",
+          "source": "Number-sequences.ipynb"
+        },
+        {
+          "after": "Stock-market portfolio optimization - Data driven",
+          "before": "Stock market portfolio optimisation - Data driven",
+          "route": "/stock-market-portfolio-optimisation.html",
+          "source": "Stock-market-portfolio-optimisation.ipynb"
+        },
+        {
+          "after": "Stock-performance analysis using Python Financial Functions - Data driven",
+          "before": "Stock performance analysis using python Financial Functions - Data driven",
+          "route": "/stock-perfomance-analysis.html",
+          "source": "stock-perfomance-analysis.ipynb"
+        },
+        {
+          "after": "Stock-market candlestick charts with Plotly and Python - Data driven",
+          "before": "Stock market candlestick charts with plotly and python - Data driven",
+          "route": "/candlestick-charts-plotly.html",
+          "source": "candlestick-charts-plotly.md"
+        },
+        {
+          "after": "Testing a hypothesis on a football data set from Kaggle - Data driven",
+          "before": "Testing hypothesis on football data-set from kaggle - Data driven",
+          "route": "/testing-hypothesis-on-football-data-set.html",
+          "source": "Testing-hypothesis-on-football-data-set.ipynb"
+        },
+        {
+          "after": "Deploying a static website to Bitbucket - Data driven",
+          "before": "Deploying a static website to bitbucket - Data driven",
+          "route": "/deploying-a-static-website-to-bitbucket.html",
+          "source": "deploying-a-static-website-to-bitbucket.md"
+        },
+        {
+          "after": "Add a theme and plugins to Pelican - Data driven",
+          "before": "Add theme and plugins to Pelican installation - Data driven",
+          "route": "/add-theme-and-plugins-to-pelican.html",
+          "source": "add-theme-and-plugins-to-pelican.md"
+        },
+        {
+          "after": "Install Pelican and create a project skeleton - Data driven",
+          "before": "Install Pelican and create project skeleton - Data driven",
+          "route": "/install-pelican-and-create-project-skeleton.html",
+          "source": "install-pelican-and-create-project-skeleton.md"
+        },
+        {
+          "after": "Use XGBoost on indicators, ARIMA, and FFT features from OHLCV data - Data driven",
+          "before": "Using XGBoost regressor on Indicators, ARIMA and FFT of ohlcv data - Data driven",
+          "route": "/feature-engineering-on-ohlcv-candles-wit-xgboost.html",
+          "source": "feature-engineering-on-ohlcv-candles-wit-xgboost.ipynb"
+        }
+      ]
+    },
+    "inventory": {
+      "canonical_contract": "https://nekrasovp.ru<manifest route>",
+      "counts": {
+        "articles": 46,
+        "languages": {
+          "en": 42,
+          "ru": 4
+        },
+        "markdown": 35,
+        "notebooks": 11,
+        "statuses": {
+          "archive": 16,
+          "deprecated": 8,
+          "keep": 13,
+          "refresh": 9
+        }
+      },
+      "manifest_sha256": "2c66cf1012cf52f3482b9ad6704b2a1ad2b76c321dc96cd20815af06eb8e5cea",
+      "metadata_records_validated": 46,
+      "source_preservation": {
+        "base_commit": "8e80e4d6ada80f9ad06896674bbcaab8f98a7bfe",
+        "dates_preserved": 46,
+        "markdown_bodies_preserved": 35,
+        "markdown_body_aggregate_sha256": "284c829c356cb3c04d1eab5201ba082fa6db6170265b651d2c3d286be170fc21",
+        "notebook_bytes_preserved": 11,
+        "notebook_source_aggregate_sha256": "06e6426f70abb024292f8b876db7a35b298117256007bd350252b86da929c99a",
+        "routes_preserved": 46,
+        "stable_metadata_preserved": 46
+      }
+    },
+    "rendered": {
+      "canonical_routes": 46,
+      "language_labels": {
+        "en": 42,
+        "ru": 4
+      },
+      "manual_source_and_render_inspection": {
+        "fixing-caching-sha2-password.md": {
+          "canonical": "https://nekrasovp.ru/fixing-caching-sha2-password.html",
+          "html_language": "en",
+          "language_label": "English",
+          "notice_text": "Outdated content warning. This article is deprecated and may contain outdated or unsafe guidance. Verify current documentation before use.",
+          "route": "/fixing-caching-sha2-password.html",
+          "status": "deprecated",
+          "title": "Authentication plugin caching_sha2_password cannot be loaded - Data driven"
+        },
+        "mkrf-spb-geo-data.ipynb": {
+          "canonical": "https://nekrasovp.ru/mkrf-spb-geo-data.html",
+          "html_language": "ru",
+          "language_label": "Русский",
+          "notice_text": "Исторический материал. Статья сохранена как исторический материал и может не отражать современные практики.",
+          "route": "/mkrf-spb-geo-data.html",
+          "status": "archive",
+          "title": "Визуализация картографических данных в Jupyter Notebook - Data driven"
+        },
+        "technical-debt-examples.md": {
+          "canonical": "https://nekrasovp.ru/technical-debt-examples.html",
+          "html_language": "ru",
+          "language_label": "Русский",
+          "notice_text": null,
+          "route": "/technical-debt-examples.html",
+          "status": "refresh",
+          "title": "Примеры технического долга - Data driven"
+        },
+        "update-django-user-password.md": {
+          "canonical": "https://nekrasovp.ru/update-django-user-password.html",
+          "html_language": "en",
+          "language_label": "English",
+          "notice_text": null,
+          "route": "/update-django-user-password.html",
+          "status": "keep",
+          "title": "Update Django user password - Data driven"
+        }
+      },
+      "noindex_from_status": 0,
+      "notices": {
+        "archive": 16,
+        "deprecated": 8,
+        "keep": 0,
+        "refresh": 0
+      },
+      "routes": 46
+    }
   },
   "site_base_commit": "cac7d59b7a691ebdedea17f5978ce24693830bf8",
   "warning_ledger": {

--- a/migration/site002v/validate.py
+++ b/migration/site002v/validate.py
@@ -17,6 +17,11 @@ from pathlib import Path
 from typing import Any, Sequence
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from migration.site003 import validate as site003_validation  # noqa: E402
+
 CONTENT_ROOT = REPO_ROOT / "content"
 FULL_MANIFEST = REPO_ROOT / "migration/production_parity/inputs/legacy_routes.tsv"
 NOTEBOOK_MANIFEST = REPO_ROOT / "migration/site002v/notebooks.tsv"
@@ -32,9 +37,10 @@ EXPECTED_MARKDOWN = 35
 EXPECTED_NOTEBOOKS = 11
 EXPECTED_MISSING_ALT = 57
 EXPECTED_EMPTY_ALT = 2
-EXPECTED_TITLE_GAPS = 8
-EXPECTED_READER_LANGUAGE_ABSENT = 11
-EXPECTED_RENDERED_LANGUAGE_GAPS = 1
+EXPECTED_TITLE_GAPS = 0
+EXPECTED_READER_LANGUAGE_ABSENT = 0
+EXPECTED_RENDERED_LANGUAGE_GAPS = 0
+EXPECTED_TITLE_OVERRIDES = 28
 REQUIRED_CORPUS_OUTPUT_MODES = {"code", "image", "markdown", "png", "svg", "table"}
 
 
@@ -416,6 +422,7 @@ def _build_command(python: Path, output: Path) -> list[str]:
 def _gate_command(
     python: Path,
     *,
+    baseline_metadata: Path,
     content_root: Path,
     output_root: Path,
     evidence_out: Path,
@@ -427,7 +434,7 @@ def _gate_command(
         "--expected-manifest",
         str(FULL_MANIFEST),
         "--baseline-metadata",
-        str(BASELINE_METADATA),
+        str(baseline_metadata),
         "--content-root",
         str(content_root),
         "--output-root",
@@ -447,6 +454,39 @@ def _gate_command(
         "--evidence-out",
         str(evidence_out),
     ]
+
+
+def _write_site003_baseline_overlay(path: Path) -> dict[str, Any]:
+    payload = json.loads(BASELINE_METADATA.read_text(encoding="utf-8"))
+    pages = {page["path"]: page for page in payload["pages"]}
+    changed: list[dict[str, str]] = []
+    for row in _load_tsv(FULL_MANIFEST):
+        page = pages[row["route"]]
+        expected_title = f"{row['title']} - {site003_validation.SITENAME}"
+        if page["title"] != expected_title:
+            changed.append(
+                {
+                    "after": expected_title,
+                    "before": page["title"],
+                    "route": row["route"],
+                    "source": row["source"],
+                }
+            )
+            page["title"] = expected_title
+    if len(changed) != EXPECTED_TITLE_OVERRIDES:
+        raise RuntimeError(
+            f"SITE-003 title overlay expected {EXPECTED_TITLE_OVERRIDES} changes, "
+            f"observed {len(changed)}"
+        )
+    path.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return {
+        "frozen_baseline_sha256": _sha256(BASELINE_METADATA),
+        "overlay_sha256": _sha256(path),
+        "title_overrides": changed,
+    }
 
 
 def _metadata_observations(evidence: dict[str, Any]) -> dict[str, Any]:
@@ -533,6 +573,7 @@ def _negative_gates(
     work_root: Path,
     notebooks: list[dict[str, str]],
     positive_output: Path,
+    baseline_metadata: Path,
 ) -> dict[str, Any]:
     selected = notebooks[0]
     source_name = selected["source"]
@@ -548,6 +589,7 @@ def _negative_gates(
     missing_source = _run(
         _gate_command(
             python,
+            baseline_metadata=baseline_metadata,
             content_root=missing_source_content,
             output_root=positive_output,
             evidence_out=fixtures / "missing-source/evidence.json",
@@ -567,6 +609,7 @@ def _negative_gates(
     missing_route = _run(
         _gate_command(
             python,
+            baseline_metadata=baseline_metadata,
             content_root=CONTENT_ROOT,
             output_root=missing_route_output,
             evidence_out=fixtures / "missing-route/evidence.json",
@@ -641,6 +684,50 @@ def _negative_gates(
         source=source_name,
         tokens=("notebook_parsing", "malformed_notebook"),
     )
+
+    metadata_source = next(
+        row["source"]
+        for row in _load_tsv(FULL_MANIFEST)
+        if row["source"].casefold().endswith(".md")
+    )
+    invalid_metadata_root = fixtures / "invalid-metadata/content"
+    shutil.copytree(CONTENT_ROOT, invalid_metadata_root)
+    metadata_path = invalid_metadata_root / metadata_source
+    original_metadata = metadata_path.read_bytes()
+    cases = {
+        "invalid_language": (b"Lang", b"xx", ("invalid_language", "InvalidLanguage")),
+        "unknown_status": (b"Status", b"unknown", ("unknown_status", "UnknownStatus")),
+    }
+    for label, (field, value, tokens) in cases.items():
+        mutated, replacements = re.subn(
+            rb"(?im)^" + field + rb":[^\r\n]*",
+            field + b": " + value,
+            original_metadata,
+            count=1,
+        )
+        if replacements != 1:
+            raise RuntimeError(f"could not create {label} SITE-003 fixture")
+        metadata_path.write_bytes(mutated)
+        failure = _run(
+            [
+                str(python),
+                str(REPO_ROOT / "migration/site003/validate.py"),
+                "--content-root",
+                str(invalid_metadata_root),
+                "--manifest",
+                str(FULL_MANIFEST),
+                "--base-commit",
+                site003_validation.SITE003_BASE_COMMIT,
+            ],
+            cwd=fixtures / "invalid-metadata",
+        )
+        results[label] = _assert_typed_failure(
+            failure,
+            label=f"{label} gate",
+            source=metadata_source,
+            tokens=("inventory_validation", *tokens),
+        )
+    metadata_path.write_bytes(original_metadata)
     return results
 
 
@@ -654,6 +741,9 @@ def run(args: argparse.Namespace) -> dict[str, Any]:
 
     _verify_site_base()
     notebooks = _validate_manifests()
+    inventory = site003_validation.validate_inventory()
+    baseline_overlay = work_root / "site003-baseline-overlay.json"
+    overlay_evidence = _write_site003_baseline_overlay(baseline_overlay)
     lock_source = _verify_dependency_input()
     status_before = _git_status()
     sources_before = _source_hashes()
@@ -669,6 +759,7 @@ def run(args: argparse.Namespace) -> dict[str, Any]:
     evidence_paths: list[Path] = []
     warning_ledgers: list[dict[str, int]] = []
     observations: list[dict[str, int]] = []
+    rendered_contracts: list[dict[str, Any]] = []
 
     for number in (1, 2):
         output = work_root / f"output-{number}"
@@ -699,6 +790,7 @@ def run(args: argparse.Namespace) -> dict[str, Any]:
         gate = _run(
             _gate_command(
                 external_python,
+                baseline_metadata=baseline_overlay,
                 content_root=CONTENT_ROOT,
                 output_root=output,
                 evidence_out=evidence,
@@ -707,11 +799,19 @@ def run(args: argparse.Namespace) -> dict[str, Any]:
         )
         _require_success(gate, f"publication completeness gate {number}")
         evidence_paths.append(evidence)
+        rendered_contracts.append(
+            site003_validation.validate_output(
+                output_root=output,
+                manifest_path=FULL_MANIFEST,
+            )
+        )
 
     if evidence_paths[0].read_bytes() != evidence_paths[1].read_bytes():
         raise RuntimeError("the two normalized publication evidence files differ")
     if warning_ledgers[0] != warning_ledgers[1]:
         raise RuntimeError("the two warning ledgers differ")
+    if rendered_contracts[0] != rendered_contracts[1]:
+        raise RuntimeError("the two SITE-003 rendered contract reports differ")
     if marker.exists():
         raise RuntimeError("the build created the execution marker")
     if _source_hashes() != sources_before:
@@ -731,12 +831,18 @@ def run(args: argparse.Namespace) -> dict[str, Any]:
     if missing_modes:
         raise RuntimeError(f"representative committed output modes are missing: {missing_modes!r}")
 
-    negative = _negative_gates(external_python, work_root, notebooks, work_root / "output-1")
+    negative = _negative_gates(
+        external_python,
+        work_root,
+        notebooks,
+        work_root / "output-1",
+        baseline_overlay,
+    )
     if _source_hashes() != sources_before or _git_status() != status_before:
         raise RuntimeError("isolated negative fixtures changed repository sources or status")
 
     result = {
-        "contract": "nekrasovp-site002v-validation.v1",
+        "contract": "nekrasovp-site002v-validation.v2",
         "counts": publication["counts"],
         "dependency": {
             "direct_requirement": PLUGIN_REQUIREMENT,
@@ -766,6 +872,11 @@ def run(args: argparse.Namespace) -> dict[str, Any]:
         "publication_records": publication["records"],
         "representative_committed_output_fixture": representative,
         "site_base_commit": SITE_BASE_COMMIT,
+        "site003": {
+            "baseline_overlay": overlay_evidence,
+            "inventory": inventory,
+            "rendered": rendered_contracts[0],
+        },
         "warning_ledger": publication["warning_ledger"],
     }
     report_out.parent.mkdir(parents=True, exist_ok=True)

--- a/migration/site003/README.md
+++ b/migration/site003/README.md
@@ -1,0 +1,71 @@
+# Legacy metadata normalization (SITE-003)
+
+SITE-003 makes `migration/production_parity/inputs/legacy_routes.tsv` the
+authoritative metadata contract for exactly 46 legacy articles: 35 Markdown
+sources and 11 notebooks with adjacent `.nbdata` files.
+
+## Contract
+
+Before Pelican starts, `validate.py` requires a one-to-one source/route mapping,
+the exact manifest title, historical date, language, and lifecycle status for
+every source. The accepted aggregate is:
+
+- status: 9 `refresh`, 13 `keep`, 16 `archive`, and 8 `deprecated`;
+- language: 42 `en` and 4 `ru`;
+- source kinds: 35 Markdown and 11 notebooks.
+
+Unknown status and missing or invalid language produce typed, source-aware
+failures during `inventory_validation`. The same gate compares Markdown body
+bytes, notebook bytes, historical dates, routes, and all non-SITE-003 metadata
+against base commit `8e80e4d6ada80f9ad06896674bbcaab8f98a7bfe`.
+
+Pelican's reserved publication `Status` cannot carry the lifecycle vocabulary.
+The small `plugins/site_metadata.py` adapter retains it as
+`article.lifecycle_status` and publishes the already-manifested legacy article.
+It does not add `noindex`. Explicit non-default language uses the same
+`{slug}.html` route contract as default-language content.
+
+Rendered output must contain one visible English or Russian language label.
+`archive` receives a historical-content notice; `deprecated` receives the
+stronger outdated-content warning; `refresh` and `keep` receive no notice.
+Canonical URLs are deterministically `https://nekrasovp.ru` plus the manifest
+route.
+
+## Validation
+
+Run from the repository root on Python 3.12:
+
+```sh
+uv sync --locked --all-groups
+./scripts/site build
+./scripts/site validate
+./scripts/site test
+uv run --locked --all-groups ruff check \
+  migration/site_build migration/site002v/validate.py migration/site003 \
+  plugins/site_metadata.py
+```
+
+`./scripts/site validate` reuses the SITE-002V harness for two clean locked
+builds, exact immutable-reader provenance, no-execution/no-network checks,
+source cleanliness, publication completeness, and negative fixtures. SITE-003
+adds the pre-Pelican inventory/preservation gate and exact rendered
+route/status/language/notice checks to each pass. Its unknown-status and
+invalid-language negative fixtures join the five existing SITE-002V cases.
+
+The frozen full pre-cutover BASE-001 comparison remains a separate boundary.
+Against the SITE-003 production-intent artifact it intentionally exits 1 with
+65 differences: 28 manifest-authoritative legacy title deltas plus already-owned
+modern-page, theme/home, feed, asset, and redirect differences. The checker is
+not weakened and its RED result is not treated as SITE-003 success.
+
+## Manual semantic inspection record
+
+The deterministic evidence records source metadata and parsed rendered output
+for these representatives:
+
+- `technical-debt-examples.md`: `refresh`, Russian, no notice;
+- `update-django-user-password.md`: `keep`, English, no notice;
+- `mkrf-spb-geo-data.ipynb`: `archive`, Russian historical notice;
+- `fixing-caching-sha2-password.md`: `deprecated`, English stronger warning.
+
+This is source/rendered-route inspection, not visual or user acceptance.

--- a/migration/site003/__init__.py
+++ b/migration/site003/__init__.py
@@ -1,0 +1,1 @@
+"""SITE-003 metadata and rendered-contract validation."""

--- a/migration/site003/validate.py
+++ b/migration/site003/validate.py
@@ -1,0 +1,561 @@
+"""Validate the authoritative SITE-003 source and rendered metadata contracts."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import re
+import subprocess
+import sys
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any, Mapping, Sequence
+
+from bs4 import BeautifulSoup
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CONTENT_ROOT = REPO_ROOT / "content"
+MANIFEST = REPO_ROOT / "migration/production_parity/inputs/legacy_routes.tsv"
+SITE003_BASE_COMMIT = "8e80e4d6ada80f9ad06896674bbcaab8f98a7bfe"
+SITEURL = "https://nekrasovp.ru"
+SITENAME = "Data driven"
+EXPECTED_ARTICLES = 46
+EXPECTED_MARKDOWN = 35
+EXPECTED_NOTEBOOKS = 11
+EXPECTED_STATUS_COUNTS = {
+    "archive": 16,
+    "deprecated": 8,
+    "keep": 13,
+    "refresh": 9,
+}
+EXPECTED_LANGUAGE_COUNTS = {"en": 42, "ru": 4}
+LANGUAGE_LABELS = {"en": "English", "ru": "Русский"}
+MANIFEST_FIELDS = ("route", "published_at", "language", "status", "source", "title")
+EDITABLE_METADATA = {
+    "canonical",
+    "lang",
+    "legacy_source",
+    "modified",
+    "status",
+    "title",
+}
+MANUAL_REVIEW_SOURCES = (
+    "technical-debt-examples.md",  # refresh, ru
+    "update-django-user-password.md",  # keep, en
+    "mkrf-spb-geo-data.ipynb",  # archive, ru
+    "fixing-caching-sha2-password.md",  # deprecated, en
+)
+
+
+@dataclass(frozen=True)
+class ManifestRow:
+    route: str
+    published_at: str
+    language: str
+    status: str
+    source: str
+    title: str
+
+    @property
+    def is_notebook(self) -> bool:
+        return self.source.casefold().endswith(".ipynb")
+
+
+class Site003ValidationError(RuntimeError):
+    """A stable, source-aware SITE-003 contract failure."""
+
+    error_code = "validation_error"
+    stage = "inventory_validation"
+
+    def __init__(self, source: str, message: str):
+        self.source = source
+        self.message = message
+        super().__init__(
+            "SITE-003 pre-Pelican validation failed: "
+            f"source={source!r} stage={self.stage} error_code={self.error_code} "
+            f"error_type={type(self).__name__} {message}"
+        )
+
+
+class InvalidManifest(Site003ValidationError):
+    error_code = "invalid_manifest"
+
+
+class DuplicateManifestMapping(Site003ValidationError):
+    error_code = "duplicate_manifest_mapping"
+
+
+class MissingExpectedSource(Site003ValidationError):
+    error_code = "missing_expected_source"
+
+
+class UnexpectedLegacySource(Site003ValidationError):
+    error_code = "unexpected_legacy_source"
+
+
+class MissingMetadataField(Site003ValidationError):
+    error_code = "missing_metadata_field"
+
+
+class DuplicateMetadataField(Site003ValidationError):
+    error_code = "duplicate_metadata_field"
+
+
+class UnknownStatus(Site003ValidationError):
+    error_code = "unknown_status"
+
+
+class InvalidLanguage(Site003ValidationError):
+    error_code = "invalid_language"
+
+
+class MetadataMismatch(Site003ValidationError):
+    error_code = "metadata_mismatch"
+
+
+class SourcePreservationMismatch(Site003ValidationError):
+    error_code = "source_preservation_mismatch"
+
+
+class RenderedContractMismatch(Site003ValidationError):
+    error_code = "rendered_contract_mismatch"
+    stage = "rendered_validation"
+
+
+def _sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _sha256(path: Path) -> str:
+    return _sha256_bytes(path.read_bytes())
+
+
+def _aggregate_sha256(records: list[tuple[str, bytes]]) -> str:
+    digest = hashlib.sha256()
+    for source, value in sorted(records):
+        digest.update(source.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(hashlib.sha256(value).digest())
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def _load_manifest(path: Path) -> list[ManifestRow]:
+    try:
+        with path.open(encoding="utf-8", newline="") as stream:
+            reader = csv.DictReader(stream, delimiter="\t")
+            if tuple(reader.fieldnames or ()) != MANIFEST_FIELDS:
+                raise InvalidManifest(
+                    path.as_posix(), f"expected exact columns {MANIFEST_FIELDS!r}"
+                )
+            rows = [
+                ManifestRow(**{field: row[field] for field in MANIFEST_FIELDS})
+                for row in reader
+            ]
+    except Site003ValidationError:
+        raise
+    except Exception as error:
+        raise InvalidManifest(path.as_posix(), str(error)) from error
+
+    if len(rows) != EXPECTED_ARTICLES:
+        raise InvalidManifest(path.as_posix(), f"expected 46 rows, observed {len(rows)}")
+    sources = [row.source for row in rows]
+    routes = [row.route for row in rows]
+    if len(sources) != len(set(sources)) or len(routes) != len(set(routes)):
+        raise DuplicateManifestMapping(path.as_posix(), "sources and routes must be one-to-one")
+
+    for row in rows:
+        source = PurePosixPath(row.source)
+        if source.is_absolute() or ".." in source.parts or source.name != row.source:
+            raise InvalidManifest(row.source, "source must be one safe content-root filename")
+        if not row.route.startswith("/") or not row.route.endswith(".html"):
+            raise InvalidManifest(row.source, f"invalid route {row.route!r}")
+        if row.status not in EXPECTED_STATUS_COUNTS:
+            raise UnknownStatus(row.source, f"manifest status={row.status!r}")
+        if row.language not in EXPECTED_LANGUAGE_COUNTS:
+            raise InvalidLanguage(row.source, f"manifest language={row.language!r}")
+
+    status_counts = Counter(row.status for row in rows)
+    language_counts = Counter(row.language for row in rows)
+    if dict(sorted(status_counts.items())) != dict(sorted(EXPECTED_STATUS_COUNTS.items())):
+        raise InvalidManifest(path.as_posix(), f"unexpected status counts {dict(status_counts)!r}")
+    if dict(sorted(language_counts.items())) != dict(sorted(EXPECTED_LANGUAGE_COUNTS.items())):
+        raise InvalidManifest(
+            path.as_posix(), f"unexpected language counts {dict(language_counts)!r}"
+        )
+    return rows
+
+
+def _split_metadata(source: str, raw: bytes) -> tuple[bytes, bytes | None]:
+    if not source.casefold().endswith(".md"):
+        return raw, None
+    candidates = []
+    for delimiter in (b"\r\n\r\n", b"\n\n"):
+        position = raw.find(delimiter)
+        if position >= 0:
+            candidates.append((position, len(delimiter)))
+    if not candidates:
+        raise MissingMetadataField(source, "Markdown metadata has no terminating blank line")
+    position, length = min(candidates)
+    return raw[:position], raw[position + length :]
+
+
+def _parse_metadata(source: str, raw: bytes) -> dict[str, str]:
+    header, _body = _split_metadata(source, raw)
+    try:
+        text = header.decode("utf-8-sig")
+    except UnicodeDecodeError as error:
+        raise MetadataMismatch(source, f"metadata is not UTF-8: {error}") from error
+    result: dict[str, str] = {}
+    for line in text.splitlines():
+        match = re.match(r"^([A-Za-z][A-Za-z0-9_-]*):\s*(.*)$", line)
+        if not match:
+            continue
+        key = match.group(1).casefold()
+        if key in result:
+            raise DuplicateMetadataField(source, f"field={key!r}")
+        result[key] = match.group(2).strip()
+    return result
+
+
+def _git_blob(base_commit: str, repository_path: str) -> bytes:
+    result = subprocess.run(
+        ["git", "show", f"{base_commit}:{repository_path}"],
+        cwd=REPO_ROOT,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if result.returncode:
+        detail = result.stderr.decode("utf-8", errors="replace").strip()
+        raise SourcePreservationMismatch(repository_path, f"base object unavailable: {detail}")
+    return result.stdout
+
+
+def _expected_route(source: str, metadata: Mapping[str, str]) -> str:
+    save_as = metadata.get("save_as")
+    if save_as:
+        return "/" + save_as.lstrip("/")
+    slug = metadata.get("slug")
+    if not slug:
+        raise MissingMetadataField(source, "field='slug'")
+    return f"/{slug}.html"
+
+
+def _require_metadata(row: ManifestRow, metadata: Mapping[str, str]) -> None:
+    for field in ("title", "date", "slug", "lang", "status"):
+        if not metadata.get(field):
+            raise MissingMetadataField(row.source, f"field={field!r}")
+    status = metadata["status"]
+    language = metadata["lang"]
+    if status not in EXPECTED_STATUS_COUNTS:
+        raise UnknownStatus(row.source, f"source status={status!r}")
+    if language not in EXPECTED_LANGUAGE_COUNTS:
+        raise InvalidLanguage(row.source, f"source language={language!r}")
+
+    expected = {
+        "date": row.published_at,
+        "language": row.language,
+        "route": row.route,
+        "status": row.status,
+        "title": row.title,
+    }
+    actual = {
+        "date": metadata["date"][:10],
+        "language": language,
+        "route": _expected_route(row.source, metadata),
+        "status": status,
+        "title": metadata["title"],
+    }
+    for field, expected_value in expected.items():
+        if actual[field] != expected_value:
+            raise MetadataMismatch(
+                row.source,
+                f"field={field!r} expected={expected_value!r} actual={actual[field]!r}",
+            )
+    if "modified" in metadata:
+        raise MetadataMismatch(row.source, "modified is not supported without factual evidence")
+
+
+def _stable_metadata(metadata: Mapping[str, str]) -> dict[str, str]:
+    return {key: value for key, value in metadata.items() if key not in EDITABLE_METADATA}
+
+
+def validate_inventory(
+    *,
+    content_root: Path = CONTENT_ROOT,
+    manifest_path: Path = MANIFEST,
+    base_commit: str = SITE003_BASE_COMMIT,
+) -> dict[str, Any]:
+    """Validate all 46 source records before Pelican reads any article."""
+
+    rows = _load_manifest(manifest_path)
+    manifest_sources = {row.source for row in rows}
+    actual_sources = {
+        path.name
+        for pattern in ("*.md", "*.ipynb")
+        for path in content_root.glob(pattern)
+        if path.is_file()
+    }
+    missing = sorted(manifest_sources - actual_sources)
+    unexpected = sorted(actual_sources - manifest_sources)
+    if missing:
+        raise MissingExpectedSource(missing[0], f"missing sources={missing!r}")
+    if unexpected:
+        raise UnexpectedLegacySource(unexpected[0], f"unexpected sources={unexpected!r}")
+
+    expected_nbdata = {
+        Path(row.source).with_suffix(".nbdata").name for row in rows if row.is_notebook
+    }
+    actual_nbdata = {path.name for path in content_root.glob("*.nbdata") if path.is_file()}
+    if expected_nbdata != actual_nbdata:
+        missing_metadata = sorted(expected_nbdata - actual_nbdata)
+        unexpected_metadata = sorted(actual_nbdata - expected_nbdata)
+        source = (missing_metadata or unexpected_metadata)[0]
+        raise MissingExpectedSource(
+            source,
+            f"nbdata missing={missing_metadata!r} unexpected={unexpected_metadata!r}",
+        )
+
+    markdown_bodies: list[tuple[str, bytes]] = []
+    notebook_bytes: list[tuple[str, bytes]] = []
+    metadata_records = 0
+    for row in rows:
+        source_path = content_root / row.source
+        source_raw = source_path.read_bytes()
+        metadata_path = (
+            source_path.with_suffix(".nbdata") if row.is_notebook else source_path
+        )
+        metadata_raw = metadata_path.read_bytes()
+        metadata = _parse_metadata(row.source, metadata_raw)
+        _require_metadata(row, metadata)
+        metadata_records += 1
+
+        base_source_raw = _git_blob(base_commit, f"content/{row.source}")
+        if row.is_notebook:
+            if source_raw != base_source_raw:
+                raise SourcePreservationMismatch(row.source, "notebook bytes differ from base")
+            notebook_bytes.append((row.source, source_raw))
+            metadata_name = Path(row.source).with_suffix(".nbdata").name
+            base_metadata_raw = _git_blob(base_commit, f"content/{metadata_name}")
+            base_metadata = _parse_metadata(row.source, base_metadata_raw)
+        else:
+            _current_header, current_body = _split_metadata(row.source, source_raw)
+            _base_header, base_body = _split_metadata(row.source, base_source_raw)
+            if current_body != base_body:
+                raise SourcePreservationMismatch(row.source, "Markdown body bytes differ from base")
+            assert current_body is not None
+            markdown_bodies.append((row.source, current_body))
+            base_metadata = _parse_metadata(row.source, base_source_raw)
+
+        if _stable_metadata(metadata) != _stable_metadata(base_metadata):
+            raise SourcePreservationMismatch(
+                row.source, "non-SITE-003 metadata fields differ from base"
+            )
+
+    markdown_count = sum(not row.is_notebook for row in rows)
+    notebook_count = sum(row.is_notebook for row in rows)
+    if (markdown_count, notebook_count) != (EXPECTED_MARKDOWN, EXPECTED_NOTEBOOKS):
+        raise InvalidManifest(
+            manifest_path.as_posix(),
+            f"expected 35 Markdown + 11 notebooks, observed {markdown_count} + {notebook_count}",
+        )
+
+    return {
+        "canonical_contract": f"{SITEURL}<manifest route>",
+        "counts": {
+            "articles": len(rows),
+            "languages": dict(sorted(Counter(row.language for row in rows).items())),
+            "markdown": markdown_count,
+            "notebooks": notebook_count,
+            "statuses": dict(sorted(Counter(row.status for row in rows).items())),
+        },
+        "manifest_sha256": _sha256(manifest_path),
+        "metadata_records_validated": metadata_records,
+        "source_preservation": {
+            "base_commit": base_commit,
+            "dates_preserved": len(rows),
+            "markdown_bodies_preserved": markdown_count,
+            "markdown_body_aggregate_sha256": _aggregate_sha256(markdown_bodies),
+            "notebook_bytes_preserved": notebook_count,
+            "notebook_source_aggregate_sha256": _aggregate_sha256(notebook_bytes),
+            "routes_preserved": len(rows),
+            "stable_metadata_preserved": len(rows),
+        },
+    }
+
+
+def _canonical_link(soup: BeautifulSoup) -> str | None:
+    for link in soup.find_all("link"):
+        rel = link.get("rel") or []
+        tokens = rel if isinstance(rel, list) else str(rel).split()
+        if "canonical" in {token.casefold() for token in tokens}:
+            href = link.get("href")
+            return str(href) if href is not None else None
+    return None
+
+
+def validate_output(
+    *,
+    output_root: Path,
+    manifest_path: Path = MANIFEST,
+) -> dict[str, Any]:
+    """Validate the 46 generated routes, notices, languages, and canonicals."""
+
+    rows = _load_manifest(manifest_path)
+    notice_counts: Counter[str] = Counter()
+    label_counts: Counter[str] = Counter()
+    manual: dict[str, Any] = {}
+    for row in rows:
+        route_path = output_root / row.route.lstrip("/")
+        if not route_path.is_file():
+            raise RenderedContractMismatch(row.source, f"missing route {row.route!r}")
+        soup = BeautifulSoup(route_path.read_text(encoding="utf-8"), "html.parser")
+        html = soup.find("html")
+        html_lang = html.get("lang") if html else None
+        if html_lang != row.language:
+            raise RenderedContractMismatch(
+                row.source,
+                f"html lang expected={row.language!r} actual={html_lang!r}",
+            )
+        expected_title = f"{row.title} - {SITENAME}"
+        rendered_title = soup.title.get_text(strip=True) if soup.title else None
+        if rendered_title != expected_title:
+            raise RenderedContractMismatch(
+                row.source,
+                f"title expected={expected_title!r} actual={rendered_title!r}",
+            )
+        canonical = _canonical_link(soup)
+        expected_canonical = f"{SITEURL}{row.route}"
+        if canonical != expected_canonical:
+            raise RenderedContractMismatch(
+                row.source,
+                f"canonical expected={expected_canonical!r} actual={canonical!r}",
+            )
+
+        article = soup.find("article", attrs={"data-content-status": True})
+        rendered_status = article.get("data-content-status") if article else None
+        if rendered_status != row.status:
+            raise RenderedContractMismatch(
+                row.source,
+                f"status expected={row.status!r} actual={rendered_status!r}",
+            )
+
+        labels = soup.select(".article-language[data-language-code]")
+        expected_label = LANGUAGE_LABELS[row.language]
+        if len(labels) != 1 or labels[0].get("data-language-code") != row.language:
+            raise RenderedContractMismatch(row.source, "expected exactly one language label")
+        label_text = " ".join(labels[0].get_text(" ", strip=True).split())
+        if label_text != expected_label:
+            raise RenderedContractMismatch(
+                row.source,
+                f"language label expected={expected_label!r} actual={label_text!r}",
+            )
+        label_counts[row.language] += 1
+
+        notices = soup.select(".content-notice[data-content-status]")
+        if row.status in {"archive", "deprecated"}:
+            if len(notices) != 1 or notices[0].get("data-content-status") != row.status:
+                raise RenderedContractMismatch(row.source, "expected one status-specific notice")
+            notice_counts[row.status] += 1
+            notice_text = " ".join(notices[0].get_text(" ", strip=True).split())
+        else:
+            if notices:
+                raise RenderedContractMismatch(
+                    row.source, f"misleading notice rendered for {row.status!r}"
+                )
+            notice_text = None
+
+        for robots in soup.find_all("meta", attrs={"name": re.compile(r"^robots$", re.I)}):
+            if "noindex" in str(robots.get("content") or "").casefold():
+                raise RenderedContractMismatch(
+                    row.source, "lifecycle status silently introduced noindex"
+                )
+
+        if row.source in MANUAL_REVIEW_SOURCES:
+            manual[row.source] = {
+                "canonical": canonical,
+                "html_language": html_lang,
+                "language_label": label_text,
+                "notice_text": notice_text,
+                "route": row.route,
+                "status": row.status,
+                "title": rendered_title,
+            }
+
+    expected_notices = {"archive": 16, "deprecated": 8}
+    if dict(sorted(notice_counts.items())) != expected_notices:
+        raise RenderedContractMismatch(
+            manifest_path.as_posix(), f"unexpected notice counts {dict(notice_counts)!r}"
+        )
+    if dict(sorted(label_counts.items())) != EXPECTED_LANGUAGE_COUNTS:
+        raise RenderedContractMismatch(
+            manifest_path.as_posix(), f"unexpected language-label counts {dict(label_counts)!r}"
+        )
+    if set(manual) != set(MANUAL_REVIEW_SOURCES):
+        raise RenderedContractMismatch(
+            manifest_path.as_posix(), f"manual review examples incomplete: {sorted(manual)!r}"
+        )
+
+    return {
+        "canonical_routes": len(rows),
+        "language_labels": dict(sorted(label_counts.items())),
+        "manual_source_and_render_inspection": manual,
+        "noindex_from_status": 0,
+        "notices": {**expected_notices, "keep": 0, "refresh": 0},
+        "routes": len(rows),
+    }
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser(description=__doc__)
+    result.add_argument("--content-root", type=Path, default=CONTENT_ROOT)
+    result.add_argument("--manifest", type=Path, default=MANIFEST)
+    result.add_argument("--base-commit", default=SITE003_BASE_COMMIT)
+    result.add_argument("--output-root", type=Path)
+    result.add_argument("--evidence-out", type=Path)
+    return result
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parser().parse_args(argv)
+    try:
+        evidence = {
+            "contract": "nekrasovp-site003-metadata.v1",
+            "inventory": validate_inventory(
+                content_root=args.content_root.resolve(),
+                manifest_path=args.manifest.resolve(),
+                base_commit=args.base_commit,
+            ),
+        }
+        if args.output_root:
+            evidence["rendered"] = validate_output(
+                output_root=args.output_root.resolve(),
+                manifest_path=args.manifest.resolve(),
+            )
+        if args.evidence_out:
+            args.evidence_out.parent.mkdir(parents=True, exist_ok=True)
+            args.evidence_out.write_text(
+                json.dumps(evidence, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+                encoding="utf-8",
+            )
+    except Site003ValidationError as error:
+        print(error, file=sys.stderr)
+        return 1
+    counts = evidence["inventory"]["counts"]
+    message = (
+        "SITE-003 pre-Pelican validation passed: "
+        f"{counts['markdown']} Markdown + {counts['notebooks']} notebooks = "
+        f"{counts['articles']} sources"
+    )
+    if "rendered" in evidence:
+        message += "; 46 rendered route/status/language/notice contracts passed"
+    print(message)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/migration/site_build/README.md
+++ b/migration/site_build/README.md
@@ -49,13 +49,14 @@ uses `build/markdown`, deletes that explicit directory before generation, and
 treats every Pelican warning as fatal.
 
 `./scripts/site build` is the full production-intent build. It always uses
-`build/production` and passes `--fatal errors`; the separate SITE-002V
-validation command independently requires all 46 historical article routes.
+`build/production` and passes `--fatal errors`. SITE-003 inventory validation
+runs before Pelican and exact rendered metadata validation runs afterward.
 
 `./scripts/site validate` creates an external locked environment, proves the
 exact installed Git provenance of the notebook reader, runs and gates two clean
-46-article builds, and runs the isolated negative and no-execution cases. See
-`migration/site002v/README.md` for the complete contract.
+46-article builds, and runs the isolated negative and no-execution cases. It
+also reuses the SITE-003 inventory, preservation, and rendered metadata gates.
+See `migration/site002v/README.md` and `migration/site003/README.md`.
 
 `./scripts/site serve` serves the Markdown-only configuration from the explicit
 `build/local` directory with autoreload. It deliberately uses the same

--- a/migration/site_build/markdownconf.py
+++ b/migration/site_build/markdownconf.py
@@ -12,4 +12,4 @@ MARKUP = ("md",)
 IGNORE_FILES = [*IGNORE_FILES, "*.ipynb"]  # noqa: F405
 THEME = str(REPO_ROOT / "theme")
 PLUGIN_PATHS = [str(REPO_ROOT / "plugins")]
-PLUGINS = ["i18n_subsites", "related_posts", "tag_cloud"]
+PLUGINS = ["i18n_subsites", "related_posts", "site_metadata", "tag_cloud"]

--- a/migration/site_build/site.py
+++ b/migration/site_build/site.py
@@ -21,6 +21,7 @@ DEFAULT_CONFIGS = {
     "serve": Path("migration/site_build/markdownconf.py"),
 }
 SITE002V_VALIDATOR = REPO_ROOT / "migration/site002v/validate.py"
+SITE003_VALIDATOR = REPO_ROOT / "migration/site003/validate.py"
 
 
 def resolve_from_repo(value: str | Path) -> Path:
@@ -75,6 +76,12 @@ def run(command: Sequence[str]) -> int:
         return 130
 
 
+def run_site003_preflight() -> int:
+    """Reject invalid lifecycle status or language before Pelican starts."""
+
+    return run([sys.executable, str(SITE003_VALIDATOR)])
+
+
 def parser() -> argparse.ArgumentParser:
     result = argparse.ArgumentParser(description=__doc__)
     subparsers = result.add_subparsers(dest="command", required=True)
@@ -108,13 +115,27 @@ def main(argv: Sequence[str] | None = None) -> int:
         if args.report_out:
             command.extend(["--report-out", args.report_out])
         return run(command)
-    return run(
+    preflight = run_site003_preflight()
+    if preflight:
+        return preflight
+    output = args.output or DEFAULT_OUTPUTS[args.command]
+    build = run(
         pelican_command(
             args.command,
-            output=args.output,
+            output=output,
             config=args.config,
             port=getattr(args, "port", 8000),
         )
+    )
+    if build or args.command != "build":
+        return build
+    return run(
+        [
+            sys.executable,
+            str(SITE003_VALIDATOR),
+            "--output-root",
+            str(resolve_from_repo(output)),
+        ]
     )
 
 

--- a/migration/site_build/tests/test_site003.py
+++ b/migration/site_build/tests/test_site003.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+VALIDATOR = REPO_ROOT / "migration/site003/validate.py"
+spec = importlib.util.spec_from_file_location("site003_validate", VALIDATOR)
+assert spec and spec.loader
+site003 = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = site003
+spec.loader.exec_module(site003)
+
+EXPECTED_LANGUAGE_COUNTS = site003.EXPECTED_LANGUAGE_COUNTS
+EXPECTED_STATUS_COUNTS = site003.EXPECTED_STATUS_COUNTS
+InvalidLanguage = site003.InvalidLanguage
+ManifestRow = site003.ManifestRow
+UnknownStatus = site003.UnknownStatus
+_require_metadata = site003._require_metadata
+validate_inventory = site003.validate_inventory
+
+
+def test_authoritative_inventory_matches_all_46_sources() -> None:
+    evidence = validate_inventory()
+
+    assert evidence["counts"] == {
+        "articles": 46,
+        "languages": EXPECTED_LANGUAGE_COUNTS,
+        "markdown": 35,
+        "notebooks": 11,
+        "statuses": EXPECTED_STATUS_COUNTS,
+    }
+    assert evidence["source_preservation"]["markdown_bodies_preserved"] == 35
+    assert evidence["source_preservation"]["notebook_bytes_preserved"] == 11
+    assert evidence["source_preservation"]["dates_preserved"] == 46
+    assert evidence["source_preservation"]["routes_preserved"] == 46
+
+
+def _row() -> ManifestRow:
+    return ManifestRow(
+        route="/example.html",
+        published_at="2020-01-01",
+        language="en",
+        status="keep",
+        source="example.md",
+        title="Example",
+    )
+
+
+def _metadata() -> dict[str, str]:
+    return {
+        "date": "2020-01-01 15:00",
+        "lang": "en",
+        "slug": "example",
+        "status": "keep",
+        "title": "Example",
+    }
+
+
+def test_unknown_status_is_typed_and_source_aware() -> None:
+    metadata = _metadata()
+    metadata["status"] = "unknown"
+
+    with pytest.raises(UnknownStatus, match=r"source='example\.md'.*unknown_status"):
+        _require_metadata(_row(), metadata)
+
+
+def test_invalid_language_is_typed_and_source_aware() -> None:
+    metadata = _metadata()
+    metadata["lang"] = "xx"
+
+    with pytest.raises(InvalidLanguage, match=r"source='example\.md'.*invalid_language"):
+        _require_metadata(_row(), metadata)
+
+
+def test_validator_is_the_pre_pelican_entrypoint() -> None:
+    site_script = (REPO_ROOT / "migration/site_build/site.py").read_text(encoding="utf-8")
+
+    assert "run_site003_preflight()" in site_script
+    assert "if preflight:" in site_script
+    assert site_script.index("if preflight:") < site_script.index("pelican_command(", 3000)

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -14,6 +14,10 @@ PATH = 'content'
 
 DEFAULT_LANG = 'en'
 
+# Explicit source language must not change the authoritative legacy route.
+ARTICLE_LANG_URL = '{slug}.html'
+ARTICLE_LANG_SAVE_AS = '{slug}.html'
+
 # Feed generation is usually not desired when developing
 FEED_ALL_ATOM = None
 CATEGORY_FEED_ATOM = None
@@ -92,6 +96,7 @@ PLUGIN_PATHS = ['plugins/']
 PLUGINS = [
     'i18n_subsites',
     'related_posts',
+    'site_metadata',
     'tag_cloud',
     'pelican.plugins.ipynb_reader',
 ]

--- a/plugins/site_metadata.py
+++ b/plugins/site_metadata.py
@@ -1,0 +1,25 @@
+"""Expose SITE-003 lifecycle metadata without consuming Pelican publication status."""
+
+from pelican import signals
+from pelican.contents import Article
+
+LIFECYCLE_STATUSES = {"archive", "deprecated", "keep", "refresh"}
+
+
+def normalize_article_status(content):
+    """Keep lifecycle status for templates while publishing every legacy article."""
+
+    if not isinstance(content, Article) or "status" not in content.metadata:
+        return
+    lifecycle_status = str(content.metadata["status"]).casefold()
+    if lifecycle_status not in LIFECYCLE_STATUSES:
+        raise ValueError(
+            f"unknown SITE-003 lifecycle status {lifecycle_status!r} "
+            f"for {content.source_path}"
+        )
+    content.lifecycle_status = lifecycle_status
+    content.status = "published"
+
+
+def register():
+    signals.content_object_init.connect(normalize_article_status)

--- a/theme/templates/article.html
+++ b/theme/templates/article.html
@@ -69,7 +69,7 @@
 
 {% block content %}
     <section id="content">
-        <article>
+        <article data-content-status="{{ article.lifecycle_status }}">
             <header class="page-header">
                 <h1>
                     <a href="{{ SITEURL }}/{{ article.url }}"
@@ -85,6 +85,25 @@
                         {% include "includes/article_info.html" %}
                     </div>
                 </div>
+                {% if article.lifecycle_status == 'archive' %}
+                    <div class="alert alert-warning content-notice content-notice-archive"
+                         data-content-status="archive" role="note">
+                        {% if article.lang == 'ru' %}
+                            <strong>Исторический материал.</strong>
+                            Статья сохранена как исторический материал и может не отражать современные практики.
+                        {% else %}
+                            <strong>Historical content.</strong>
+                            This article is preserved as a historical record and may not reflect current practices.
+                        {% endif %}
+                    </div>
+                {% elif article.lifecycle_status == 'deprecated' %}
+                    <div class="alert alert-danger content-notice content-notice-deprecated"
+                         data-content-status="deprecated" role="alert">
+                        <strong>Outdated content warning.</strong>
+                        This article is deprecated and may contain outdated or unsafe guidance.
+                        Verify current documentation before use.
+                    </div>
+                {% endif %}
                 {{ article.content }}
             </div>
             <!-- /.entry-content -->

--- a/theme/templates/includes/article_info.html
+++ b/theme/templates/includes/article_info.html
@@ -3,6 +3,10 @@
     <span class="published">
         <i class="fa fa-calendar"></i><time datetime="{{ article.date.isoformat() }}"> {{ article.locale_date }}</time>
     </span>
+    <span class="label label-info">Language</span>
+    <span class="article-language" data-language-code="{{ article.lang }}">
+        {% if article.lang == 'ru' %}Русский{% else %}English{% endif %}
+    </span>
     {% if SHOW_DATE_MODIFIED %}
         {% if article.modified %}
           <span class="label label-default">{{ _('Modified') }}</span>


### PR DESCRIPTION
## Summary

- normalize metadata for exactly 46 authoritative legacy sources (35 Markdown and 11 adjacent notebook metadata files)
- add typed pre-Pelican inventory/preservation validation and minimal lifecycle-status rendering
- resolve SITE-002V notebook title/language deviations from 8/11/1 to 0/0/0 while preserving the immutable reader pin
- reuse the existing two-build SITE-002V harness for rendered route/status/language/notice evidence

## Contract evidence

- statuses: 9 refresh, 13 keep, 16 archive, 8 deprecated
- languages: 42 en, 4 ru
- notices: 16 archive, 8 deprecated, 0 keep, 0 refresh
- 46 dates, 46 routes, 35 Markdown bodies, and 11 notebook byte streams preserved against `8e80e4d6ada80f9ad06896674bbcaab8f98a7bfe`
- no `.ipynb`, frozen BASE-001 metadata, `uv.lock`, article body, deployment, Pages, or noindex-policy change

## Validation

- `./scripts/site build`: 46 articles; exact route/status/language/canonical/notice contracts passed
- `./scripts/site validate`: two clean locked builds; 7 positive/negative gates; no execution, kernel start, network connection, or source mutation
- deterministic report SHA-256: `ddb4fdf814f5ffa4a102c30911793c4f213e2ba05d63439dc6765eb88b6d27e2`
- `./scripts/site test`: 14 passed
- BASE-001 checker unit tests: 6 passed
- Ruff, actionlint, lock check, diff check, and credential scan passed

## Boundaries

The frozen full pre-cutover BASE-001 artifact comparison remains intentionally RED with 65 already-owned production/theme/feed/asset/redirect and manifest-title differences; the checker was not weakened. The accepted accessibility ledger remains 57 generated fallback alts and 2 authored empty alts. This PR is draft, does not deploy production, and makes no visual or user-acceptance claim.