### PR TITLE
SITE-006V: integrate immutable theme candidate

### DIFF
--- a/.github/workflows/site002v.yml
+++ b/.github/workflows/site002v.yml
@@ -1,4 +1,4 @@
-name: SITE-002V and SITE-003
+name: SITE-002V, SITE-003, and SITE-006V
 
 on:
   pull_request:
@@ -18,7 +18,7 @@ env:
 
 jobs:
   immutable-reader:
-    name: Immutable reader and normalized 46-article corpus
+    name: Immutable reader, theme, and normalized 46-article corpus
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
@@ -47,11 +47,18 @@ jobs:
           uv run --locked --all-groups python - <<'PY'
           from importlib.metadata import version
 
-          for name in ("pelican-jupyter", "pelican", "nbconvert", "nbformat", "jinja2"):
+          for name in (
+              "pelican-engineering-theme",
+              "pelican-jupyter",
+              "pelican",
+              "nbconvert",
+              "nbformat",
+              "jinja2",
+          ):
               print(f"{name}=={version(name)}")
           PY
 
-      - name: Run two full builds and SITE-002V plus SITE-003 gates
+      - name: Run two full builds and cumulative migration gates
         run: |
           ./scripts/site validate \
             --work-root "$RUNNER_TEMP/site002v" \
@@ -64,7 +71,7 @@ jobs:
           ./scripts/site test
           uv run --locked --all-groups ruff check \
             migration/site_build migration/site002v/validate.py \
-            migration/site003 plugins/site_metadata.py
+            migration/site003 migration/site006v plugins/site_metadata.py
           git diff --check
           test -z "$(git status --porcelain=v1 --untracked-files=all)"
           github_token_prefix='github''_pat_'

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 help:
 	@echo 'make markdown  Markdown-only smoke build (warnings are errors)'
 	@echo 'make build     Full production-intent build (46 historical articles)'
-	@echo 'make validate  Full SITE-002V/SITE-003 deterministic and negative gates'
+	@echo 'make validate  Full SITE-002V/SITE-003/SITE-006V deterministic gates'
 	@echo 'make serve     Local Markdown-only server (PORT=8000 by default)'
 	@echo 'make test      SITE-001 acceptance tests'
 

--- a/migration/site002v/evidence/validation.json
+++ b/migration/site002v/evidence/validation.json
@@ -1,5 +1,5 @@
 {
-  "contract": "nekrasovp-site002v-validation.v2",
+  "contract": "nekrasovp-site002v-site003-site006v-validation.v3",
   "counts": {
     "articles": 46,
     "markdown": 35,
@@ -19,8 +19,12 @@
     "plugin_commit": "137e1eb0ea620f1b15fff0ba81725eea23de1b7a"
   },
   "determinism": {
-    "normalized_publication_evidence_sha256": "f13343b164247f5e205fe058733b779a55bfb4de81561bcff5dc49ddf1c45f6d",
+    "normalized_asset_evidence_identical": true,
+    "normalized_metadata_evidence_identical": true,
+    "normalized_publication_evidence_sha256": "03b7699bd9bd33387da84a570193d05ce4b4d66539f4e099b3ee67d37b5fa35a",
     "publication_evidence_identical": true,
+    "route_evidence_identical": true,
+    "theme_identity_evidence_identical": true,
     "warning_ledgers_identical": true
   },
   "emitted_build_warning_ledger": {
@@ -282,9 +286,9 @@
     {
       "baseline_metadata": {
         "language": "en",
-        "page_title": "COVID-19 data visualization - Data driven"
+        "page_title": "COVID-19 data visualization — Data driven"
       },
-      "content_class_sha256": "a54a5595a88c8ce90c087250e639e206dd5961ac004c4da3ffbf686a3bfbb5f5",
+      "content_class_sha256": "f30669c4767cbf9d7b6bfd32fba3e439027b7786ddd6b8db7cc536ea4ec6b2a8",
       "content_modes": [
         "code",
         "image",
@@ -311,7 +315,7 @@
       },
       "rendered_observation": {
         "html_lang": "en",
-        "page_title": "COVID-19 data visualization - Data driven"
+        "page_title": "COVID-19 data visualization — Data driven"
       },
       "route": "/covid-dashboard.html",
       "source": "covid-dashboard.ipynb",
@@ -341,9 +345,9 @@
     {
       "baseline_metadata": {
         "language": "en",
-        "page_title": "Use XGBoost on indicators, ARIMA, and FFT features from OHLCV data - Data driven"
+        "page_title": "Use XGBoost on indicators, ARIMA, and FFT features from OHLCV data — Data driven"
       },
-      "content_class_sha256": "c16faac6d9170e93e573debae65a29dda9298c4513ae8c4f1185bdbb0ab87981",
+      "content_class_sha256": "887228276262b3206c0b3a07621a3311ea4d7b8adb97168557071fa42123f6cf",
       "content_modes": [
         "code",
         "image",
@@ -372,7 +376,7 @@
       },
       "rendered_observation": {
         "html_lang": "en",
-        "page_title": "Use XGBoost on indicators, ARIMA, and FFT features from OHLCV data - Data driven"
+        "page_title": "Use XGBoost on indicators, ARIMA, and FFT features from OHLCV data — Data driven"
       },
       "route": "/feature-engineering-on-ohlcv-candles-wit-xgboost.html",
       "source": "feature-engineering-on-ohlcv-candles-wit-xgboost.ipynb",
@@ -422,9 +426,9 @@
     {
       "baseline_metadata": {
         "language": "en",
-        "page_title": "Simulating a Galton board with Markov chains - Data driven"
+        "page_title": "Simulating a Galton board with Markov chains — Data driven"
       },
-      "content_class_sha256": "21c33a13ee32446bec0b0f5be345c664de6653ac21e216e325c5a431a2fae979",
+      "content_class_sha256": "9ab970c6c925d6ecc0ea09190f18259fc71ee15a181c3067069cd794b8656b21",
       "content_modes": [
         "code",
         "image",
@@ -450,7 +454,7 @@
       },
       "rendered_observation": {
         "html_lang": "en",
-        "page_title": "Simulating a Galton board with Markov chains - Data driven"
+        "page_title": "Simulating a Galton board with Markov chains — Data driven"
       },
       "route": "/markov-chain-bean-machine.html",
       "source": "markov-chain-bean-machine.ipynb",
@@ -460,9 +464,9 @@
     {
       "baseline_metadata": {
         "language": "ru",
-        "page_title": "Визуализация картографических данных в Jupyter Notebook - Data driven"
+        "page_title": "Визуализация картографических данных в Jupyter Notebook — Data driven"
       },
-      "content_class_sha256": "fe4a6bb0779dcff010e3c989b3efcd68306935386ee83ecd928e9355ac38a912",
+      "content_class_sha256": "20290c3ab303c53e4b336d8685ea1ce51f996196cdaea447fcc494009008e7d6",
       "content_modes": [
         "code",
         "markdown"
@@ -486,7 +490,7 @@
       },
       "rendered_observation": {
         "html_lang": "ru",
-        "page_title": "Визуализация картографических данных в Jupyter Notebook - Data driven"
+        "page_title": "Визуализация картографических данных в Jupyter Notebook — Data driven"
       },
       "route": "/mkrf-spb-geo-data.html",
       "source": "mkrf-spb-geo-data.ipynb",
@@ -501,9 +505,9 @@
     {
       "baseline_metadata": {
         "language": "en",
-        "page_title": "Number-sequence visualization with Python - Data driven"
+        "page_title": "Number-sequence visualization with Python — Data driven"
       },
-      "content_class_sha256": "09049d751c8b74caee0bab75ce713373b39162b2653d35ff41b82e84596a61d2",
+      "content_class_sha256": "d231b6726778d7f5df79344abb08ede89bb574804fe106b8c18e20f35484d334",
       "content_modes": [
         "code",
         "image",
@@ -528,7 +532,7 @@
       },
       "rendered_observation": {
         "html_lang": "en",
-        "page_title": "Number-sequence visualization with Python - Data driven"
+        "page_title": "Number-sequence visualization with Python — Data driven"
       },
       "route": "/number-sequences.html",
       "source": "Number-sequences.ipynb",
@@ -538,9 +542,9 @@
     {
       "baseline_metadata": {
         "language": "en",
-        "page_title": "Pascal's Triangle - Data driven"
+        "page_title": "Pascal's Triangle — Data driven"
       },
-      "content_class_sha256": "2bb2ffc5b2a906374a1d4da9100d9ed7d1ce09a98bf098759ece338b21ae3b19",
+      "content_class_sha256": "367920b742816f7d9b2bb00b4315873087fa8b67c369b72123c3d2b67a9dd981",
       "content_modes": [
         "code",
         "image",
@@ -567,7 +571,7 @@
       },
       "rendered_observation": {
         "html_lang": "en",
-        "page_title": "Pascal's Triangle - Data driven"
+        "page_title": "Pascal's Triangle — Data driven"
       },
       "route": "/pascals-triangle.html",
       "source": "pascals-triangle.ipynb",
@@ -632,9 +636,9 @@
     {
       "baseline_metadata": {
         "language": "en",
-        "page_title": "Getting stock data with pandas-datareader - Data driven"
+        "page_title": "Getting stock data with pandas-datareader — Data driven"
       },
-      "content_class_sha256": "1a1d5fa049c31fdec0efb6b2e4f78bdae24f6fa05bda6bd864c3c719707c81ac",
+      "content_class_sha256": "1aa1784b20a6a3e54d863eaf46a112d90fc6f458b74afece13d56a0734d6be28",
       "content_modes": [
         "code",
         "image",
@@ -661,7 +665,7 @@
       },
       "rendered_observation": {
         "html_lang": "en",
-        "page_title": "Getting stock data with pandas-datareader - Data driven"
+        "page_title": "Getting stock data with pandas-datareader — Data driven"
       },
       "route": "/stock-data-with-pandas-datareader.html",
       "source": "Getting-stock-data-with-pandas-datareader.ipynb",
@@ -671,9 +675,9 @@
     {
       "baseline_metadata": {
         "language": "en",
-        "page_title": "Stock-market portfolio optimization - Data driven"
+        "page_title": "Stock-market portfolio optimization — Data driven"
       },
-      "content_class_sha256": "8a9ba2144250a8fae04b4b86e76da308e98f09daa8626200626f1364bce04844",
+      "content_class_sha256": "84419a2e20176eff9e425c58a3083c2ca999c4a7366ec03b7cab7f3461c23917",
       "content_modes": [
         "code",
         "image",
@@ -701,7 +705,7 @@
       },
       "rendered_observation": {
         "html_lang": "en",
-        "page_title": "Stock-market portfolio optimization - Data driven"
+        "page_title": "Stock-market portfolio optimization — Data driven"
       },
       "route": "/stock-market-portfolio-optimisation.html",
       "source": "Stock-market-portfolio-optimisation.ipynb",
@@ -711,9 +715,9 @@
     {
       "baseline_metadata": {
         "language": "en",
-        "page_title": "Stock-performance analysis using Python Financial Functions - Data driven"
+        "page_title": "Stock-performance analysis using Python Financial Functions — Data driven"
       },
-      "content_class_sha256": "9e7d77439fe20d5be9e7eb1d227240101dcf4c9b8456da0d85d1bd0fca105dab",
+      "content_class_sha256": "9d71cb1a7cfa610f58d941befb737bb88fc3faeec2550cb2ad9bba64cdcb67fd",
       "content_modes": [
         "code",
         "image",
@@ -741,7 +745,7 @@
       },
       "rendered_observation": {
         "html_lang": "en",
-        "page_title": "Stock-performance analysis using Python Financial Functions - Data driven"
+        "page_title": "Stock-performance analysis using Python Financial Functions — Data driven"
       },
       "route": "/stock-perfomance-analysis.html",
       "source": "stock-perfomance-analysis.ipynb",
@@ -756,9 +760,9 @@
     {
       "baseline_metadata": {
         "language": "en",
-        "page_title": "Testing a hypothesis on a football data set from Kaggle - Data driven"
+        "page_title": "Testing a hypothesis on a football data set from Kaggle — Data driven"
       },
-      "content_class_sha256": "8b722cafe93ddce4b908b0366cb14e72345a9ae181b0b5e18d8a2fa8057b42c7",
+      "content_class_sha256": "d106d8815e5df90e3de419eff4c9d4d52bee9b4c8ca69939950fe6e065483d3f",
       "content_modes": [
         "code",
         "image",
@@ -789,7 +793,7 @@
       },
       "rendered_observation": {
         "html_lang": "en",
-        "page_title": "Testing a hypothesis on a football data set from Kaggle - Data driven"
+        "page_title": "Testing a hypothesis on a football data set from Kaggle — Data driven"
       },
       "route": "/testing-hypothesis-on-football-data-set.html",
       "source": "Testing-hypothesis-on-football-data-set.ipynb",
@@ -809,9 +813,9 @@
     {
       "baseline_metadata": {
         "language": "en",
-        "page_title": "Use Cython to speed up Python code - Data driven"
+        "page_title": "Use Cython to speed up Python code — Data driven"
       },
-      "content_class_sha256": "f383afdac3cc9a36d27599e8b7b1b1825c6b6f1e58acad5e3df9177874d4b611",
+      "content_class_sha256": "80802a9eebb526570cd542ecdf11a9cab9a6e4bf2582294c257d836a8cf12926",
       "content_modes": [
         "code",
         "markdown"
@@ -833,7 +837,7 @@
       },
       "rendered_observation": {
         "html_lang": "en",
-        "page_title": "Use Cython to speed up Python code - Data driven"
+        "page_title": "Use Cython to speed up Python code — Data driven"
       },
       "route": "/use-cython-to-speedup-your-python-code.html",
       "source": "Use Cython to speed up your Python code.ipynb",
@@ -863,175 +867,283 @@
   "site003": {
     "baseline_overlay": {
       "frozen_baseline_sha256": "b209396e3d2926af6cdf69e8feab3afa1adec2fbadc13517866e3f3d2ecec653",
-      "overlay_sha256": "fcd3384160992071eaa81bd1a3d509eaeac071bf48f8cb9b7bf6c09a2445abe9",
+      "overlay_sha256": "0632ce4b86e3906dd7b499f89fab590b9e7e9a1cbb4e7393ee30dd2d05836409",
       "title_overrides": [
         {
-          "after": "Python app with Poetry and Docker - Data driven",
+          "after": "Примеры технического долга — Data driven",
+          "before": "Примеры технического долга - Data driven",
+          "route": "/technical-debt-examples.html",
+          "source": "technical-debt-examples.md"
+        },
+        {
+          "after": "Что такое технический долг? — Data driven",
+          "before": "Что такое технический долг? - Data driven",
+          "route": "/what-is-technical-debt.html",
+          "source": "what-is-technical-debt.md"
+        },
+        {
+          "after": "Update Django user password — Data driven",
+          "before": "Update Django user password - Data driven",
+          "route": "/update-django-user-password.html",
+          "source": "update-django-user-password.md"
+        },
+        {
+          "after": "MySQL server has gone away errors — Data driven",
+          "before": "MySQL server has gone away errors - Data driven",
+          "route": "/mysql-server-errors.html",
+          "source": "mysql-server-errors.md"
+        },
+        {
+          "after": "Python app with Poetry and Docker — Data driven",
           "before": "Python app with poetry & docker - Data driven",
           "route": "/python-poetry-docker.html",
           "source": "python-poetry-docker.md"
         },
         {
-          "after": "How to list users in Linux - Data driven",
+          "after": "How to list users in Linux — Data driven",
           "before": "How to List Users in Linux - Data driven",
           "route": "/linux-list-users.html",
           "source": "linux-list-users.md"
         },
         {
-          "after": "Authentication plugin caching_sha2_password cannot be loaded - Data driven",
+          "after": "Change swap size in Ubuntu — Data driven",
+          "before": "Change swap size in Ubuntu - Data driven",
+          "route": "/linux-change-swap-size.html",
+          "source": "linux-change-swap-size.md"
+        },
+        {
+          "after": "Python object reference — Data driven",
+          "before": "Python object reference - Data driven",
+          "route": "/python-object-reference.html",
+          "source": "python-object-reference.md"
+        },
+        {
+          "after": "Authentication plugin caching_sha2_password cannot be loaded — Data driven",
           "before": "Authentication plugin 'caching_sha2_password' cannot be loaded - Data driven",
           "route": "/fixing-caching-sha2-password.html",
           "source": "fixing-caching-sha2-password.md"
         },
         {
-          "after": "How to rebase a Git branch - Data driven",
+          "after": "Use Black and organize imports on save in VSCode — Data driven",
+          "before": "Use Black and organize imports on save in VSCode - Data driven",
+          "route": "/python-black-isort.html",
+          "source": "vscode-black-isort.md"
+        },
+        {
+          "after": "How to rebase a Git branch — Data driven",
           "before": "How to rebase git branch - Data driven",
           "route": "/git-rebase.html",
           "source": "git-rebase.md"
         },
         {
-          "after": "Capturing shell output in Python - Data driven",
+          "after": "Capturing shell output in Python — Data driven",
           "before": "Capturing shell output in python - Data driven",
           "route": "/shell-capture.html",
           "source": "shell-capture.md"
         },
         {
-          "after": "Why Python needs the Global Interpreter Lock and how it works - Data driven",
+          "after": "Why Python needs the Global Interpreter Lock and how it works — Data driven",
           "before": "Why you need Python Global Interpreter Lock and how it works - Data driven",
           "route": "/python-gil.html",
           "source": "python-gil.md"
         },
         {
-          "after": "Find which process is listening on a specific port - Data driven",
+          "after": "Find which process is listening on a specific port — Data driven",
           "before": "Ways to find out which process is listening on a specific port - Data driven",
           "route": "/linux-port.html",
           "source": "linux-port.md"
         },
         {
-          "after": "Install NVM, Node, and Yarn - Data driven",
+          "after": "Custom logger handlers — Data driven",
+          "before": "Custom logger handlers - Data driven",
+          "route": "/custom-logger.html",
+          "source": "custom-logger.md"
+        },
+        {
+          "after": "Custom color formatter with Python logging — Data driven",
+          "before": "Custom color formatter with Python logging - Data driven",
+          "route": "/color-formatter.html",
+          "source": "color-formatter.md"
+        },
+        {
+          "after": "Analytics checklist — Data driven",
+          "before": "Analytics checklist - Data driven",
+          "route": "/analytics-checklist.html",
+          "source": "analytics-checklist.md"
+        },
+        {
+          "after": "Install NVM, Node, and Yarn — Data driven",
           "before": "Install nvm, node and yarn for your Node.js application - Data driven",
           "route": "/install-nvm-node-yarn.html",
           "source": "install-nvm-node-yarn.md"
         },
         {
-          "after": "Setting up Nginx and Gunicorn for a Flask application - Data driven",
+          "after": "Setting up Nginx and Gunicorn for a Flask application — Data driven",
           "before": "Setting Up Nginx, Gunicorn for Flask app - Data driven",
           "route": "/setting-up-nginx-gunicorn-flask.html",
           "source": "setting-up-nginx-gunicorn-flask.md"
         },
         {
-          "after": "Building a job queue - Data driven",
+          "after": "Building a job queue — Data driven",
           "before": "Building job queue - Data driven",
           "route": "/building-job-queue.html",
           "source": "building-job-queue.md"
         },
         {
-          "after": "Setting up GitLab CI for a Python application - Data driven",
+          "after": "Setting up GitLab CI for a Python application — Data driven",
           "before": "Setting Up GitLab CI for a Python Application - Data driven",
           "route": "/setting-up-gitlab-ci.html",
           "source": "setting-up-gitlab-ci.md"
         },
         {
-          "after": "Obstacles to successful DevOps - Data driven",
+          "after": "Obstacles to successful DevOps — Data driven",
           "before": "Obstacles to successful devops - Data driven",
           "route": "/devops-questions.html",
           "source": "devops-questions.md"
         },
         {
-          "after": "Визуализация картографических данных в Jupyter Notebook - Data driven",
+          "after": "Визуализация картографических данных в Jupyter Notebook — Data driven",
           "before": "Визуализации картографических данных в Jupyter notebook - Data driven",
           "route": "/mkrf-spb-geo-data.html",
           "source": "mkrf-spb-geo-data.ipynb"
         },
         {
-          "after": "Understand a GraphQL schema - Data driven",
+          "after": "Шаблон ретроспективы — Data driven",
+          "before": "Шаблон ретроспективы - Data driven",
+          "route": "/retrospective-template.html",
+          "source": "Retrospective-template.md"
+        },
+        {
+          "after": "Understand a GraphQL schema — Data driven",
           "before": "Understand GraphQL Schema - Data driven",
           "route": "/graphql-schema.html",
           "source": "graphql-schema.md"
         },
         {
-          "after": "COVID-19 data visualization - Data driven",
+          "after": "COVID-19 data visualization — Data driven",
           "before": "Just another COVID-19 data visualisation - Data driven",
           "route": "/covid-dashboard.html",
           "source": "covid-dashboard.ipynb"
         },
         {
-          "after": "How to get a well-developed IT solution - Data driven",
+          "after": "How to share data with a statistician — Data driven",
+          "before": "How to share data with a statistician - Data driven",
+          "route": "/share-data.html",
+          "source": "share-data.md"
+        },
+        {
+          "after": "Publishing articles workflow — Data driven",
+          "before": "Publishing articles workflow - Data driven",
+          "route": "/publishing-articles-workflow.html",
+          "source": "publishing-articles-workflow.md"
+        },
+        {
+          "after": "How to get a well-developed IT solution — Data driven",
           "before": "How to get well-developed IT solution - Data driven",
           "route": "/business-it-solutions.html",
           "source": "business-it-solutions.md"
         },
         {
-          "after": "Move a blog to GitHub and automate deployment with Git hooks - Data driven",
+          "after": "Move a blog to GitHub and automate deployment with Git hooks — Data driven",
           "before": "Move blog to github and automate deploying with git hooks - Data driven",
           "route": "/pelican-github-script-automation.html",
           "source": "pelican-github-script-automation.md"
         },
         {
-          "after": "Essay template - Data driven",
+          "after": "Essay template — Data driven",
           "before": "Essay(simple paper) template - Data driven",
           "route": "/essay-paper-template.html",
           "source": "essay-paper-template.md"
         },
         {
-          "after": "Use Cython to speed up Python code - Data driven",
+          "after": "Pascal's Triangle — Data driven",
+          "before": "Pascal's Triangle - Data driven",
+          "route": "/pascals-triangle.html",
+          "source": "pascals-triangle.ipynb"
+        },
+        {
+          "after": "Simulating a Galton board with Markov chains — Data driven",
+          "before": "Simulating a Galton board with Markov chains - Data driven",
+          "route": "/markov-chain-bean-machine.html",
+          "source": "markov-chain-bean-machine.ipynb"
+        },
+        {
+          "after": "Use Cython to speed up Python code — Data driven",
           "before": "Use Cython to speed up your Python code - Data driven",
           "route": "/use-cython-to-speedup-your-python-code.html",
           "source": "Use Cython to speed up your Python code.ipynb"
         },
         {
-          "after": "Number-sequence visualization with Python - Data driven",
+          "after": "Number-sequence visualization with Python — Data driven",
           "before": "Number sequences visualisation with python - Data driven",
           "route": "/number-sequences.html",
           "source": "Number-sequences.ipynb"
         },
         {
-          "after": "Stock-market portfolio optimization - Data driven",
+          "after": "Stock-market portfolio optimization — Data driven",
           "before": "Stock market portfolio optimisation - Data driven",
           "route": "/stock-market-portfolio-optimisation.html",
           "source": "Stock-market-portfolio-optimisation.ipynb"
         },
         {
-          "after": "Stock-performance analysis using Python Financial Functions - Data driven",
+          "after": "Stock-performance analysis using Python Financial Functions — Data driven",
           "before": "Stock performance analysis using python Financial Functions - Data driven",
           "route": "/stock-perfomance-analysis.html",
           "source": "stock-perfomance-analysis.ipynb"
         },
         {
-          "after": "Stock-market candlestick charts with Plotly and Python - Data driven",
+          "after": "Stock-market candlestick charts with Plotly and Python — Data driven",
           "before": "Stock market candlestick charts with plotly and python - Data driven",
           "route": "/candlestick-charts-plotly.html",
           "source": "candlestick-charts-plotly.md"
         },
         {
-          "after": "Testing a hypothesis on a football data set from Kaggle - Data driven",
+          "after": "Testing a hypothesis on a football data set from Kaggle — Data driven",
           "before": "Testing hypothesis on football data-set from kaggle - Data driven",
           "route": "/testing-hypothesis-on-football-data-set.html",
           "source": "Testing-hypothesis-on-football-data-set.ipynb"
         },
         {
-          "after": "Deploying a static website to Bitbucket - Data driven",
+          "after": "Getting stock data with pandas-datareader — Data driven",
+          "before": "Getting stock data with pandas-datareader - Data driven",
+          "route": "/stock-data-with-pandas-datareader.html",
+          "source": "Getting-stock-data-with-pandas-datareader.ipynb"
+        },
+        {
+          "after": "Upgrading OpenSSL on Ubuntu 18.04 — Data driven",
+          "before": "Upgrading OpenSSL on Ubuntu 18.04 - Data driven",
+          "route": "/upgrading-openssl-ubuntu.html",
+          "source": "openssl-ubuntu.md"
+        },
+        {
+          "after": "Deploying a static website to Bitbucket — Data driven",
           "before": "Deploying a static website to bitbucket - Data driven",
           "route": "/deploying-a-static-website-to-bitbucket.html",
           "source": "deploying-a-static-website-to-bitbucket.md"
         },
         {
-          "after": "Add a theme and plugins to Pelican - Data driven",
+          "after": "Add a theme and plugins to Pelican — Data driven",
           "before": "Add theme and plugins to Pelican installation - Data driven",
           "route": "/add-theme-and-plugins-to-pelican.html",
           "source": "add-theme-and-plugins-to-pelican.md"
         },
         {
-          "after": "Install Pelican and create a project skeleton - Data driven",
+          "after": "Install Pelican and create a project skeleton — Data driven",
           "before": "Install Pelican and create project skeleton - Data driven",
           "route": "/install-pelican-and-create-project-skeleton.html",
           "source": "install-pelican-and-create-project-skeleton.md"
         },
         {
-          "after": "Use XGBoost on indicators, ARIMA, and FFT features from OHLCV data - Data driven",
+          "after": "Use XGBoost on indicators, ARIMA, and FFT features from OHLCV data — Data driven",
           "before": "Using XGBoost regressor on Indicators, ARIMA and FFT of ohlcv data - Data driven",
           "route": "/feature-engineering-on-ohlcv-candles-wit-xgboost.html",
           "source": "feature-engineering-on-ohlcv-candles-wit-xgboost.ipynb"
+        },
+        {
+          "after": "Arbitrage — Data driven",
+          "before": "Arbitrage - Data driven",
+          "route": "/arbitrage.html",
+          "source": "arbitrage.md"
         }
       ]
     },
@@ -1076,19 +1188,19 @@
           "canonical": "https://nekrasovp.ru/fixing-caching-sha2-password.html",
           "html_language": "en",
           "language_label": "English",
-          "notice_text": "Outdated content warning. This article is deprecated and may contain outdated or unsafe guidance. Verify current documentation before use.",
+          "notice_text": "Deprecated content This article is deprecated and may contain outdated or unsafe guidance. Verify current documentation before use.",
           "route": "/fixing-caching-sha2-password.html",
           "status": "deprecated",
-          "title": "Authentication plugin caching_sha2_password cannot be loaded - Data driven"
+          "title": "Authentication plugin caching_sha2_password cannot be loaded — Data driven"
         },
         "mkrf-spb-geo-data.ipynb": {
           "canonical": "https://nekrasovp.ru/mkrf-spb-geo-data.html",
           "html_language": "ru",
           "language_label": "Русский",
-          "notice_text": "Исторический материал. Статья сохранена как исторический материал и может не отражать современные практики.",
+          "notice_text": "Archived content Статья сохранена как исторический материал и может не отражать современные практики.",
           "route": "/mkrf-spb-geo-data.html",
           "status": "archive",
-          "title": "Визуализация картографических данных в Jupyter Notebook - Data driven"
+          "title": "Визуализация картографических данных в Jupyter Notebook — Data driven"
         },
         "technical-debt-examples.md": {
           "canonical": "https://nekrasovp.ru/technical-debt-examples.html",
@@ -1097,7 +1209,7 @@
           "notice_text": null,
           "route": "/technical-debt-examples.html",
           "status": "refresh",
-          "title": "Примеры технического долга - Data driven"
+          "title": "Примеры технического долга — Data driven"
         },
         "update-django-user-password.md": {
           "canonical": "https://nekrasovp.ru/update-django-user-password.html",
@@ -1106,7 +1218,7 @@
           "notice_text": null,
           "route": "/update-django-user-password.html",
           "status": "keep",
-          "title": "Update Django user password - Data driven"
+          "title": "Update Django user password — Data driven"
         }
       },
       "noindex_from_status": 0,
@@ -1117,6 +1229,1193 @@
         "refresh": 0
       },
       "routes": 46
+    }
+  },
+  "site006v": {
+    "candidate": {
+      "direct_requirement": "pelican-engineering-theme @ git+https://github.com/nekrasovp/pelican-engineering-theme.git@027a170ac6c8288347de5353569a089c526afae2",
+      "installed": {
+        "active_theme_matches_public_api": true,
+        "commit_id": "027a170ac6c8288347de5353569a089c526afae2",
+        "direct_url": {
+          "url": "https://github.com/nekrasovp/pelican-engineering-theme.git",
+          "vcs_info": {
+            "commit_id": "027a170ac6c8288347de5353569a089c526afae2",
+            "requested_revision": "027a170ac6c8288347de5353569a089c526afae2",
+            "vcs": "git"
+          }
+        },
+        "distribution_root": "site-packages",
+        "get_theme_path": "site-packages/pelican_engineering_theme/theme",
+        "import_path": "site-packages/pelican_engineering_theme/__init__.py",
+        "outside_source_checkouts": true,
+        "override_path": "site/templates",
+        "requested_revision": "027a170ac6c8288347de5353569a089c526afae2",
+        "version": "0.1.0"
+      },
+      "lock_source": "https://github.com/nekrasovp/pelican-engineering-theme.git?rev=027a170ac6c8288347de5353569a089c526afae2#027a170ac6c8288347de5353569a089c526afae2",
+      "override_boundary": {
+        "documented_public_blocks": [
+          "body_class",
+          "body_end",
+          "body_start",
+          "canonical",
+          "content",
+          "content_footer",
+          "content_header",
+          "head_meta",
+          "head_styles",
+          "hero",
+          "html_head",
+          "page_class",
+          "scripts",
+          "site_footer",
+          "site_header",
+          "site_navigation",
+          "structured_data",
+          "title"
+        ],
+        "public_block_count": 18,
+        "templates": [
+          {
+            "blocks": [
+              "content",
+              "content_header"
+            ],
+            "path": "templates/article.html",
+            "theme_parent": "!theme/article.html"
+          },
+          {
+            "blocks": [
+              "head_meta",
+              "head_styles",
+              "scripts"
+            ],
+            "path": "templates/base.html",
+            "theme_parent": "!theme/base.html"
+          }
+        ]
+      },
+      "theme_commit": "027a170ac6c8288347de5353569a089c526afae2",
+      "vendored_theme_configured": false,
+      "vendored_theme_present": true
+    },
+    "output": {
+      "assets": {
+        "count": 21,
+        "records": [
+          {
+            "path": "CNAME",
+            "sha256": "22dff4c8d24d7bc16fdff08edf451c871819c4b94f84f6769b90d5357f79513b",
+            "size": 13
+          },
+          {
+            "path": "images/GitLab_CI_Final_Pipeline_Condensed_Screenshot2.png",
+            "sha256": "2b866a1e8d7f2782823c0f7854a1f9d4feac36119f22ad0d05c1f5e1aba3ec55",
+            "size": 6813
+          },
+          {
+            "path": "images/GitLab_CI_Pipeline_Screenshot.png",
+            "sha256": "24ca01a8dffa670c90bf178474c67b96cd73a087cbdb43bf926ebfba578e30d9",
+            "size": 48301
+          },
+          {
+            "path": "images/aio-pika-example.png",
+            "sha256": "003f74174782f16085689413efeb526d7212064c99c24b4078ac0ce31cfff51b",
+            "size": 65573
+          },
+          {
+            "path": "images/ava2.jpg",
+            "sha256": "271a57f9dd400f07c33c416d5ed6f86f7c3a44c20571c18dd40322afd31be934",
+            "size": 15956
+          },
+          {
+            "path": "images/ava_1_147x150.jpg",
+            "sha256": "788225a60605252265fe01665e9fda65ce295d536051dd78e121a40ab1732aa3",
+            "size": 12257
+          },
+          {
+            "path": "images/business-it-solutions-1.png",
+            "sha256": "a12a02e43d00f1ad3f5631eb2def350f7d995b7492a24f2bb7b0c399e3b03ab7",
+            "size": 7158
+          },
+          {
+            "path": "images/calendar-spread-img.png",
+            "sha256": "505515dc155692a3366945fa29a46373b474bdd613e24a6e34ac4cbdec1a33fa",
+            "size": 108635
+          },
+          {
+            "path": "images/candle-desc.png",
+            "sha256": "c723e08a24f9ae8d6737d215d293c740757a2764ecc117016976cb9ac29dc9b6",
+            "size": 121975
+          },
+          {
+            "path": "images/cross-market-img.png",
+            "sha256": "ae2e577155f48f1a709ad49082ead686445a4a43bd259ff1900cf777c502826e",
+            "size": 97292
+          },
+          {
+            "path": "images/distracted-guy-tech-debt.jpeg",
+            "sha256": "8afa5e4e76bab938e7b6ca006ce7530ec2b3b8e495586b7ed7ace9faa705b824",
+            "size": 92054
+          },
+          {
+            "path": "images/graphiql1.png",
+            "sha256": "57aaa835d4ef260ee297e97a0619046e8b69cfebbc1237695418e1423b14ccf4",
+            "size": 33125
+          },
+          {
+            "path": "images/heatmap.gif",
+            "sha256": "881f5a404e3d329230fccdc34e029b5962dc7f8d068dc96e0bbea40e6fec81f8",
+            "size": 5089100
+          },
+          {
+            "path": "images/logo.png",
+            "sha256": "9b5a2bde925c630f3f04b8c7471d4162c8c41108e493dfb1205cbf0e93ab1b0d",
+            "size": 45426
+          },
+          {
+            "path": "images/logo2.png",
+            "sha256": "e25596bb1c3c28eb4cdc45f860e1daa56795a73c0c4f328178c89dbaa61c71fb",
+            "size": 943
+          },
+          {
+            "path": "images/marker-clusters.gif",
+            "sha256": "d5b58d8f2927b47709aab8b7f46fed9d5ec4710b1fbfb61138d425d10d401e23",
+            "size": 2603462
+          },
+          {
+            "path": "images/noava-160x160.png",
+            "sha256": "b37369eed0e881d76a467bfe2353ac805cc623490343ebe0cea23454bddd961a",
+            "size": 2003
+          },
+          {
+            "path": "images/python-logging.png",
+            "sha256": "14314f3ddfc48308480ca28c347932b9c0c7c58137e8531e8318c5570c003e36",
+            "size": 38407
+          },
+          {
+            "path": "images/wireframe2.png",
+            "sha256": "4cff507c4c012e53fff25385c859c18e78d8d7aaea01d5699ad202e2394366a2",
+            "size": 461523
+          },
+          {
+            "path": "theme/css/scaffold.css",
+            "sha256": "7db229ba0504f623644d79846960b7f3ca26900f6ff84178fd38a1f4949238d0",
+            "size": 23853
+          },
+          {
+            "path": "theme/js/theme.js",
+            "sha256": "6fe91df9c13d1ef92ee6a6ae0e66e89b7c56f8d3ae04306100239a8600ed7940",
+            "size": 2789
+          }
+        ],
+        "sha256": "b7cc5293fd2d898e35ede42be18e1b827969b861cd5841f58f523501041b401e"
+      },
+      "inactive_legacy_theme": {
+        "active_references": [],
+        "copied_assets": [],
+        "vendored_sources_preserved": true
+      },
+      "metadata": {
+        "records": [
+          {
+            "canonical": "https://nekrasovp.ru/add-theme-and-plugins-to-pelican.html",
+            "language": "en",
+            "route": "add-theme-and-plugins-to-pelican.html",
+            "title": "Add a theme and plugins to Pelican — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/analytics-checklist.html",
+            "language": "en",
+            "route": "analytics-checklist.html",
+            "title": "Analytics checklist — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/arbitrage.html",
+            "language": "en",
+            "route": "arbitrage.html",
+            "title": "Arbitrage — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/archives.html",
+            "language": "en",
+            "route": "archives.html",
+            "title": "Archives — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/author/nekrasov-pavel.html",
+            "language": "en",
+            "route": "author/nekrasov-pavel.html",
+            "title": "Nekrasov Pavel — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/author/nekrasov-pavel2.html",
+            "language": "en",
+            "route": "author/nekrasov-pavel2.html",
+            "title": "Nekrasov Pavel — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/author/nekrasov-pavel3.html",
+            "language": "en",
+            "route": "author/nekrasov-pavel3.html",
+            "title": "Nekrasov Pavel — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/author/nekrasov-pavel4.html",
+            "language": "en",
+            "route": "author/nekrasov-pavel4.html",
+            "title": "Nekrasov Pavel — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/author/nekrasov-pavel5.html",
+            "language": "en",
+            "route": "author/nekrasov-pavel5.html",
+            "title": "Nekrasov Pavel — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/author/nekrasov-pavel6.html",
+            "language": "en",
+            "route": "author/nekrasov-pavel6.html",
+            "title": "Nekrasov Pavel — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/author/nekrasov-pavel7.html",
+            "language": "en",
+            "route": "author/nekrasov-pavel7.html",
+            "title": "Nekrasov Pavel — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/authors.html",
+            "language": "en",
+            "route": "authors.html",
+            "title": "Authors — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/building-job-queue.html",
+            "language": "en",
+            "route": "building-job-queue.html",
+            "title": "Building a job queue — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/business-it-solutions.html",
+            "language": "en",
+            "route": "business-it-solutions.html",
+            "title": "How to get a well-developed IT solution — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/candlestick-charts-plotly.html",
+            "language": "en",
+            "route": "candlestick-charts-plotly.html",
+            "title": "Stock-market candlestick charts with Plotly and Python — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/categories.html",
+            "language": "en",
+            "route": "categories.html",
+            "title": "Categories — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/category/blog.html",
+            "language": "en",
+            "route": "category/blog.html",
+            "title": "Blog — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/category/blog2.html",
+            "language": "en",
+            "route": "category/blog2.html",
+            "title": "Blog — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/category/blog3.html",
+            "language": "en",
+            "route": "category/blog3.html",
+            "title": "Blog — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/category/blog4.html",
+            "language": "en",
+            "route": "category/blog4.html",
+            "title": "Blog — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/category/blog5.html",
+            "language": "en",
+            "route": "category/blog5.html",
+            "title": "Blog — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/category/blog6.html",
+            "language": "en",
+            "route": "category/blog6.html",
+            "title": "Blog — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/category/blog7.html",
+            "language": "en",
+            "route": "category/blog7.html",
+            "title": "Blog — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/color-formatter.html",
+            "language": "en",
+            "route": "color-formatter.html",
+            "title": "Custom color formatter with Python logging — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/covid-dashboard.html",
+            "language": "en",
+            "route": "covid-dashboard.html",
+            "title": "COVID-19 data visualization — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/custom-logger.html",
+            "language": "en",
+            "route": "custom-logger.html",
+            "title": "Custom logger handlers — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/deploying-a-static-website-to-bitbucket.html",
+            "language": "en",
+            "route": "deploying-a-static-website-to-bitbucket.html",
+            "title": "Deploying a static website to Bitbucket — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/devops-questions.html",
+            "language": "en",
+            "route": "devops-questions.html",
+            "title": "Obstacles to successful DevOps — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/essay-paper-template.html",
+            "language": "en",
+            "route": "essay-paper-template.html",
+            "title": "Essay template — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/feature-engineering-on-ohlcv-candles-wit-xgboost.html",
+            "language": "en",
+            "route": "feature-engineering-on-ohlcv-candles-wit-xgboost.html",
+            "title": "Use XGBoost on indicators, ARIMA, and FFT features from OHLCV data — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/fixing-caching-sha2-password.html",
+            "language": "en",
+            "route": "fixing-caching-sha2-password.html",
+            "title": "Authentication plugin caching_sha2_password cannot be loaded — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/git-rebase.html",
+            "language": "en",
+            "route": "git-rebase.html",
+            "title": "How to rebase a Git branch — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/graphql-schema.html",
+            "language": "en",
+            "route": "graphql-schema.html",
+            "title": "Understand a GraphQL schema — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/index.html",
+            "language": "en",
+            "route": "index.html",
+            "title": "Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/index2.html",
+            "language": "en",
+            "route": "index2.html",
+            "title": "Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/index3.html",
+            "language": "en",
+            "route": "index3.html",
+            "title": "Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/index4.html",
+            "language": "en",
+            "route": "index4.html",
+            "title": "Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/index5.html",
+            "language": "en",
+            "route": "index5.html",
+            "title": "Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/index6.html",
+            "language": "en",
+            "route": "index6.html",
+            "title": "Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/index7.html",
+            "language": "en",
+            "route": "index7.html",
+            "title": "Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/install-nvm-node-yarn.html",
+            "language": "en",
+            "route": "install-nvm-node-yarn.html",
+            "title": "Install NVM, Node, and Yarn — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/install-pelican-and-create-project-skeleton.html",
+            "language": "en",
+            "route": "install-pelican-and-create-project-skeleton.html",
+            "title": "Install Pelican and create a project skeleton — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/linux-change-swap-size.html",
+            "language": "en",
+            "route": "linux-change-swap-size.html",
+            "title": "Change swap size in Ubuntu — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/linux-list-users.html",
+            "language": "en",
+            "route": "linux-list-users.html",
+            "title": "How to list users in Linux — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/linux-port.html",
+            "language": "en",
+            "route": "linux-port.html",
+            "title": "Find which process is listening on a specific port — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/markov-chain-bean-machine.html",
+            "language": "en",
+            "route": "markov-chain-bean-machine.html",
+            "title": "Simulating a Galton board with Markov chains — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/mkrf-spb-geo-data.html",
+            "language": "ru",
+            "route": "mkrf-spb-geo-data.html",
+            "title": "Визуализация картографических данных в Jupyter Notebook — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/mysql-server-errors.html",
+            "language": "en",
+            "route": "mysql-server-errors.html",
+            "title": "MySQL server has gone away errors — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/number-sequences.html",
+            "language": "en",
+            "route": "number-sequences.html",
+            "title": "Number-sequence visualization with Python — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/pages/about.html",
+            "language": "en",
+            "route": "pages/about.html",
+            "title": "About — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/pages/services.html",
+            "language": "en",
+            "route": "pages/services.html",
+            "title": "Services — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/pascals-triangle.html",
+            "language": "en",
+            "route": "pascals-triangle.html",
+            "title": "Pascal's Triangle — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/pelican-github-script-automation.html",
+            "language": "en",
+            "route": "pelican-github-script-automation.html",
+            "title": "Move a blog to GitHub and automate deployment with Git hooks — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/publishing-articles-workflow.html",
+            "language": "en",
+            "route": "publishing-articles-workflow.html",
+            "title": "Publishing articles workflow — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/python-black-isort.html",
+            "language": "en",
+            "route": "python-black-isort.html",
+            "title": "Use Black and organize imports on save in VSCode — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/python-gil.html",
+            "language": "en",
+            "route": "python-gil.html",
+            "title": "Why Python needs the Global Interpreter Lock and how it works — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/python-object-reference.html",
+            "language": "en",
+            "route": "python-object-reference.html",
+            "title": "Python object reference — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/python-poetry-docker.html",
+            "language": "en",
+            "route": "python-poetry-docker.html",
+            "title": "Python app with Poetry and Docker — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/retrospective-template.html",
+            "language": "ru",
+            "route": "retrospective-template.html",
+            "title": "Шаблон ретроспективы — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/setting-up-gitlab-ci.html",
+            "language": "en",
+            "route": "setting-up-gitlab-ci.html",
+            "title": "Setting up GitLab CI for a Python application — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/setting-up-nginx-gunicorn-flask.html",
+            "language": "en",
+            "route": "setting-up-nginx-gunicorn-flask.html",
+            "title": "Setting up Nginx and Gunicorn for a Flask application — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/share-data.html",
+            "language": "en",
+            "route": "share-data.html",
+            "title": "How to share data with a statistician — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/shell-capture.html",
+            "language": "en",
+            "route": "shell-capture.html",
+            "title": "Capturing shell output in Python — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/stock-data-with-pandas-datareader.html",
+            "language": "en",
+            "route": "stock-data-with-pandas-datareader.html",
+            "title": "Getting stock data with pandas-datareader — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/stock-market-portfolio-optimisation.html",
+            "language": "en",
+            "route": "stock-market-portfolio-optimisation.html",
+            "title": "Stock-market portfolio optimization — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/stock-perfomance-analysis.html",
+            "language": "en",
+            "route": "stock-perfomance-analysis.html",
+            "title": "Stock-performance analysis using Python Financial Functions — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/tag/analytics.html",
+            "language": "en",
+            "route": "tag/analytics.html",
+            "title": "analytics — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/tag/anova.html",
+            "language": "en",
+            "route": "tag/anova.html",
+            "title": "ANOVA — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/tag/arbitrage.html",
+            "language": "en",
+            "route": "tag/arbitrage.html",
+            "title": "arbitrage — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/tag/arima.html",
+            "language": "en",
+            "route": "tag/arima.html",
+            "title": "arima — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/tag/bitbucket.html",
+            "language": "en",
+            "route": "tag/bitbucket.html",
+            "title": "bitbucket — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/tag/black.html",
+            "language": "en",
+            "route": "tag/black.html",
+            "title": "black — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/tag/cython.html",
+            "language": "en",
+            "route": "tag/cython.html",
+            "title": "cython — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/tag/data.html",
+            "language": "en",
+            "route": "tag/data.html",
+            "title": "data — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/tag/development.html",
+            "language": "en",
+            "route": "tag/development.html",
+            "title": "development — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/tag/django.html",
+            "language": "en",
+            "route": "tag/django.html",
+            "title": "django — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/tag/ffn.html",
+            "language": "en",
+            "route": "tag/ffn.html",
+            "title": "ffn — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/tag/fft.html",
+            "language": "en",
+            "route": "tag/fft.html",
+            "title": "fft — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/tag/finance.html",
+            "language": "en",
+            "route": "tag/finance.html",
+            "title": "finance — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/tag/flake8.html",
+            "language": "en",
+            "route": "tag/flake8.html",
+            "title": "flake8 — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/tag/flask.html",
+            "language": "en",
+            "route": "tag/flask.html",
+            "title": "flask — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/tag/gil.html",
+            "language": "en",
+            "route": "tag/gil.html",
+            "title": "gil — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/tag/git.html",
+            "language": "en",
+            "route": "tag/git.html",
+            "title": "git — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/tag/github.html",
+            "language": "en",
+            "route": "tag/github.html",
+            "title": "github — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/tag/gitlab.html",
+            "language": "en",
+            "route": "tag/gitlab.html",
+            "title": "gitlab — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/tag/graphql.html",
+            "language": "en",
+            "route": "tag/graphql.html",
+            "title": "graphql — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/tag/gunicorn.html",
+            "language": "en",
+            "route": "tag/gunicorn.html",
+            "title": "gunicorn — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/tag/kaggle.html",
+            "language": "en",
+            "route": "tag/kaggle.html",
+            "title": "kaggle — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/tag/leaflet.html",
+            "language": "en",
+            "route": "tag/leaflet.html",
+            "title": "leaflet — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/tag/linux.html",
+            "language": "en",
+            "route": "tag/linux.html",
+            "title": "linux — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/tag/logging.html",
+            "language": "en",
+            "route": "tag/logging.html",
+            "title": "logging — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/tag/markdown.html",
+            "language": "en",
+            "route": "tag/markdown.html",
+            "title": "markdown — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/tag/math.html",
+            "language": "en",
+            "route": "tag/math.html",
+            "title": "math — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/tag/matplotlib.html",
+            "language": "en",
+            "route": "tag/matplotlib.html",
+            "title": "matplotlib — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/tag/multiprocessing.html",
+            "language": "en",
+            "route": "tag/multiprocessing.html",
+            "title": "multiprocessing — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/tag/mypy.html",
+            "language": "en",
+            "route": "tag/mypy.html",
+            "title": "mypy — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/tag/mysql.html",
+            "language": "en",
+            "route": "tag/mysql.html",
+            "title": "mysql — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/tag/networkx.html",
+            "language": "en",
+            "route": "tag/networkx.html",
+            "title": "networkx — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/tag/nginx.html",
+            "language": "en",
+            "route": "tag/nginx.html",
+            "title": "nginx — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/tag/node.html",
+            "language": "en",
+            "route": "tag/node.html",
+            "title": "node — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/tag/notebook.html",
+            "language": "en",
+            "route": "tag/notebook.html",
+            "title": "notebook — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/tag/notebook2.html",
+            "language": "en",
+            "route": "tag/notebook2.html",
+            "title": "notebook — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/tag/numpy.html",
+            "language": "en",
+            "route": "tag/numpy.html",
+            "title": "numpy — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/tag/nvm.html",
+            "language": "en",
+            "route": "tag/nvm.html",
+            "title": "nvm — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/tag/openssl.html",
+            "language": "en",
+            "route": "tag/openssl.html",
+            "title": "openssl — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/tag/pandas.html",
+            "language": "en",
+            "route": "tag/pandas.html",
+            "title": "pandas — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/tag/pelican.html",
+            "language": "en",
+            "route": "tag/pelican.html",
+            "title": "pelican — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/tag/plotly.html",
+            "language": "en",
+            "route": "tag/plotly.html",
+            "title": "plotly — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/tag/poetry.html",
+            "language": "en",
+            "route": "tag/poetry.html",
+            "title": "poetry — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/tag/portfolio.html",
+            "language": "en",
+            "route": "tag/portfolio.html",
+            "title": "portfolio — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/tag/pydot.html",
+            "language": "en",
+            "route": "tag/pydot.html",
+            "title": "pydot — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/tag/pylint.html",
+            "language": "en",
+            "route": "tag/pylint.html",
+            "title": "pylint — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/tag/pytest.html",
+            "language": "en",
+            "route": "tag/pytest.html",
+            "title": "pytest — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/tag/python.html",
+            "language": "en",
+            "route": "tag/python.html",
+            "title": "python — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/tag/python2.html",
+            "language": "en",
+            "route": "tag/python2.html",
+            "title": "python — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/tag/python3.html",
+            "language": "en",
+            "route": "tag/python3.html",
+            "title": "python — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/tag/python4.html",
+            "language": "en",
+            "route": "tag/python4.html",
+            "title": "python — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/tag/rabbitmq.html",
+            "language": "en",
+            "route": "tag/rabbitmq.html",
+            "title": "rabbitmq — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/tag/science.html",
+            "language": "en",
+            "route": "tag/science.html",
+            "title": "science — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/tag/scipy.html",
+            "language": "en",
+            "route": "tag/scipy.html",
+            "title": "scipy — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/tag/seaborn.html",
+            "language": "en",
+            "route": "tag/seaborn.html",
+            "title": "seaborn — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/tag/shell.html",
+            "language": "en",
+            "route": "tag/shell.html",
+            "title": "shell — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/tag/statistics.html",
+            "language": "en",
+            "route": "tag/statistics.html",
+            "title": "statistics — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/tag/template.html",
+            "language": "en",
+            "route": "tag/template.html",
+            "title": "template — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/tag/threading.html",
+            "language": "en",
+            "route": "tag/threading.html",
+            "title": "threading — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/tag/ubuntu.html",
+            "language": "en",
+            "route": "tag/ubuntu.html",
+            "title": "ubuntu — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/tag/vscode.html",
+            "language": "en",
+            "route": "tag/vscode.html",
+            "title": "vscode — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/tag/wbdata.html",
+            "language": "en",
+            "route": "tag/wbdata.html",
+            "title": "wbdata — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/tag/workflow.html",
+            "language": "en",
+            "route": "tag/workflow.html",
+            "title": "workflow — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/tag/xgboost.html",
+            "language": "en",
+            "route": "tag/xgboost.html",
+            "title": "xgboost — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/tag/yarn.html",
+            "language": "en",
+            "route": "tag/yarn.html",
+            "title": "yarn — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/tags.html",
+            "language": "en",
+            "route": "tags.html",
+            "title": "Tags — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/technical-debt-examples.html",
+            "language": "ru",
+            "route": "technical-debt-examples.html",
+            "title": "Примеры технического долга — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/testing-hypothesis-on-football-data-set.html",
+            "language": "en",
+            "route": "testing-hypothesis-on-football-data-set.html",
+            "title": "Testing a hypothesis on a football data set from Kaggle — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/update-django-user-password.html",
+            "language": "en",
+            "route": "update-django-user-password.html",
+            "title": "Update Django user password — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/upgrading-openssl-ubuntu.html",
+            "language": "en",
+            "route": "upgrading-openssl-ubuntu.html",
+            "title": "Upgrading OpenSSL on Ubuntu 18.04 — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/use-cython-to-speedup-your-python-code.html",
+            "language": "en",
+            "route": "use-cython-to-speedup-your-python-code.html",
+            "title": "Use Cython to speed up Python code — Data driven"
+          },
+          {
+            "canonical": "https://nekrasovp.ru/what-is-technical-debt.html",
+            "language": "ru",
+            "route": "what-is-technical-debt.html",
+            "title": "Что такое технический долг? — Data driven"
+          }
+        ],
+        "sha256": "a6439bb66bd31e90f8a6177e58790faf75787168e965a7b6e3c6f37f2642daa9"
+      },
+      "routes": {
+        "count": 138,
+        "paths": [
+          "add-theme-and-plugins-to-pelican.html",
+          "analytics-checklist.html",
+          "arbitrage.html",
+          "archives.html",
+          "author/nekrasov-pavel.html",
+          "author/nekrasov-pavel2.html",
+          "author/nekrasov-pavel3.html",
+          "author/nekrasov-pavel4.html",
+          "author/nekrasov-pavel5.html",
+          "author/nekrasov-pavel6.html",
+          "author/nekrasov-pavel7.html",
+          "authors.html",
+          "building-job-queue.html",
+          "business-it-solutions.html",
+          "candlestick-charts-plotly.html",
+          "categories.html",
+          "category/blog.html",
+          "category/blog2.html",
+          "category/blog3.html",
+          "category/blog4.html",
+          "category/blog5.html",
+          "category/blog6.html",
+          "category/blog7.html",
+          "color-formatter.html",
+          "covid-dashboard.html",
+          "custom-logger.html",
+          "deploying-a-static-website-to-bitbucket.html",
+          "devops-questions.html",
+          "essay-paper-template.html",
+          "feature-engineering-on-ohlcv-candles-wit-xgboost.html",
+          "fixing-caching-sha2-password.html",
+          "git-rebase.html",
+          "graphql-schema.html",
+          "index.html",
+          "index2.html",
+          "index3.html",
+          "index4.html",
+          "index5.html",
+          "index6.html",
+          "index7.html",
+          "install-nvm-node-yarn.html",
+          "install-pelican-and-create-project-skeleton.html",
+          "linux-change-swap-size.html",
+          "linux-list-users.html",
+          "linux-port.html",
+          "markov-chain-bean-machine.html",
+          "mkrf-spb-geo-data.html",
+          "mysql-server-errors.html",
+          "number-sequences.html",
+          "pages/about.html",
+          "pages/services.html",
+          "pascals-triangle.html",
+          "pelican-github-script-automation.html",
+          "publishing-articles-workflow.html",
+          "python-black-isort.html",
+          "python-gil.html",
+          "python-object-reference.html",
+          "python-poetry-docker.html",
+          "retrospective-template.html",
+          "setting-up-gitlab-ci.html",
+          "setting-up-nginx-gunicorn-flask.html",
+          "share-data.html",
+          "shell-capture.html",
+          "stock-data-with-pandas-datareader.html",
+          "stock-market-portfolio-optimisation.html",
+          "stock-perfomance-analysis.html",
+          "tag/analytics.html",
+          "tag/anova.html",
+          "tag/arbitrage.html",
+          "tag/arima.html",
+          "tag/bitbucket.html",
+          "tag/black.html",
+          "tag/cython.html",
+          "tag/data.html",
+          "tag/development.html",
+          "tag/django.html",
+          "tag/ffn.html",
+          "tag/fft.html",
+          "tag/finance.html",
+          "tag/flake8.html",
+          "tag/flask.html",
+          "tag/gil.html",
+          "tag/git.html",
+          "tag/github.html",
+          "tag/gitlab.html",
+          "tag/graphql.html",
+          "tag/gunicorn.html",
+          "tag/kaggle.html",
+          "tag/leaflet.html",
+          "tag/linux.html",
+          "tag/logging.html",
+          "tag/markdown.html",
+          "tag/math.html",
+          "tag/matplotlib.html",
+          "tag/multiprocessing.html",
+          "tag/mypy.html",
+          "tag/mysql.html",
+          "tag/networkx.html",
+          "tag/nginx.html",
+          "tag/node.html",
+          "tag/notebook.html",
+          "tag/notebook2.html",
+          "tag/numpy.html",
+          "tag/nvm.html",
+          "tag/openssl.html",
+          "tag/pandas.html",
+          "tag/pelican.html",
+          "tag/plotly.html",
+          "tag/poetry.html",
+          "tag/portfolio.html",
+          "tag/pydot.html",
+          "tag/pylint.html",
+          "tag/pytest.html",
+          "tag/python.html",
+          "tag/python2.html",
+          "tag/python3.html",
+          "tag/python4.html",
+          "tag/rabbitmq.html",
+          "tag/science.html",
+          "tag/scipy.html",
+          "tag/seaborn.html",
+          "tag/shell.html",
+          "tag/statistics.html",
+          "tag/template.html",
+          "tag/threading.html",
+          "tag/ubuntu.html",
+          "tag/vscode.html",
+          "tag/wbdata.html",
+          "tag/workflow.html",
+          "tag/xgboost.html",
+          "tag/yarn.html",
+          "tags.html",
+          "technical-debt-examples.html",
+          "testing-hypothesis-on-football-data-set.html",
+          "update-django-user-password.html",
+          "upgrading-openssl-ubuntu.html",
+          "use-cython-to-speedup-your-python-code.html",
+          "what-is-technical-debt.html"
+        ],
+        "sha256": "257879d1b6ab79a3b922d16fd83b4a9f2707e5ab27eb13b111bd3fff72cac332"
+      },
+      "runtime": {
+        "active_urls": [
+          "https://nekrasovp.ru/theme/css/scaffold.css",
+          "https://nekrasovp.ru/theme/js/theme.js"
+        ],
+        "external_content_media": [
+          "https://upload.wikimedia.org/wikipedia/commons/0/0d/PascalTriangleAnimated2.gif",
+          "https://upload.wikimedia.org/wikipedia/commons/thumb/f/f6/Pascal%27s_Triangle_4_paths.svg/685px-Pascal%27s_Triangle_4_paths.svg.png",
+          "https://vknight.org/blog/src/2018-11-26-galton-board/diagram/main.png",
+          "https://www.nps.gov/aboutus/news/images/CDC-coronavirus-image-23311-for-web.jpg?maxwidth=650&autorotate=false"
+        ],
+        "external_requests": []
+      },
+      "theme_assets": [
+        "theme/css/scaffold.css",
+        "theme/js/theme.js"
+      ]
+    },
+    "presentation_changes": {
+      "approved_title_separator": " — ",
+      "baseline_title_overrides": 46,
+      "legacy_presentation_selectors_required": false
     }
   },
   "site_base_commit": "cac7d59b7a691ebdedea17f5978ce24693830bf8",

--- a/migration/site002v/validate.py
+++ b/migration/site002v/validate.py
@@ -21,6 +21,7 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from migration.site003 import validate as site003_validation  # noqa: E402
+from migration.site006v import validate as site006v_validation  # noqa: E402
 
 CONTENT_ROOT = REPO_ROOT / "content"
 FULL_MANIFEST = REPO_ROOT / "migration/production_parity/inputs/legacy_routes.tsv"
@@ -40,7 +41,7 @@ EXPECTED_EMPTY_ALT = 2
 EXPECTED_TITLE_GAPS = 0
 EXPECTED_READER_LANGUAGE_ABSENT = 0
 EXPECTED_RENDERED_LANGUAGE_GAPS = 0
-EXPECTED_TITLE_OVERRIDES = 28
+EXPECTED_TITLE_OVERRIDES = 46
 REQUIRED_CORPUS_OUTPUT_MODES = {"code", "image", "markdown", "png", "svg", "table"}
 
 
@@ -462,7 +463,7 @@ def _write_site003_baseline_overlay(path: Path) -> dict[str, Any]:
     changed: list[dict[str, str]] = []
     for row in _load_tsv(FULL_MANIFEST):
         page = pages[row["route"]]
-        expected_title = f"{row['title']} - {site003_validation.SITENAME}"
+        expected_title = f"{row['title']} — {site003_validation.SITENAME}"
         if page["title"] != expected_title:
             changed.append(
                 {
@@ -745,10 +746,12 @@ def run(args: argparse.Namespace) -> dict[str, Any]:
     baseline_overlay = work_root / "site003-baseline-overlay.json"
     overlay_evidence = _write_site003_baseline_overlay(baseline_overlay)
     lock_source = _verify_dependency_input()
+    theme_input = site006v_validation.verify_dependency_input()
     status_before = _git_status()
     sources_before = _source_hashes()
     external_python = _create_locked_environment(work_root, python)
     provenance = _installed_provenance(external_python)
+    theme_provenance = site006v_validation.installed_provenance(external_python)
 
     instrumentation = work_root / "instrumentation"
     _write_instrumentation(instrumentation)
@@ -760,6 +763,7 @@ def run(args: argparse.Namespace) -> dict[str, Any]:
     warning_ledgers: list[dict[str, int]] = []
     observations: list[dict[str, int]] = []
     rendered_contracts: list[dict[str, Any]] = []
+    theme_outputs: list[dict[str, Any]] = []
 
     for number in (1, 2):
         output = work_root / f"output-{number}"
@@ -805,6 +809,7 @@ def run(args: argparse.Namespace) -> dict[str, Any]:
                 manifest_path=FULL_MANIFEST,
             )
         )
+        theme_outputs.append(site006v_validation.output_evidence(output))
 
     if evidence_paths[0].read_bytes() != evidence_paths[1].read_bytes():
         raise RuntimeError("the two normalized publication evidence files differ")
@@ -812,6 +817,8 @@ def run(args: argparse.Namespace) -> dict[str, Any]:
         raise RuntimeError("the two warning ledgers differ")
     if rendered_contracts[0] != rendered_contracts[1]:
         raise RuntimeError("the two SITE-003 rendered contract reports differ")
+    if theme_outputs[0] != theme_outputs[1]:
+        raise RuntimeError("the two normalized SITE-006V output reports differ")
     if marker.exists():
         raise RuntimeError("the build created the execution marker")
     if _source_hashes() != sources_before:
@@ -842,7 +849,7 @@ def run(args: argparse.Namespace) -> dict[str, Any]:
         raise RuntimeError("isolated negative fixtures changed repository sources or status")
 
     result = {
-        "contract": "nekrasovp-site002v-validation.v2",
+        "contract": "nekrasovp-site002v-site003-site006v-validation.v3",
         "counts": publication["counts"],
         "dependency": {
             "direct_requirement": PLUGIN_REQUIREMENT,
@@ -851,8 +858,12 @@ def run(args: argparse.Namespace) -> dict[str, Any]:
             "plugin_commit": PLUGIN_COMMIT,
         },
         "determinism": {
+            "normalized_asset_evidence_identical": True,
+            "normalized_metadata_evidence_identical": True,
             "normalized_publication_evidence_sha256": _sha256(evidence_paths[0]),
             "publication_evidence_identical": True,
+            "route_evidence_identical": True,
+            "theme_identity_evidence_identical": True,
             "warning_ledgers_identical": True,
         },
         "emitted_build_warning_ledger": warning_ledgers[0],
@@ -876,6 +887,19 @@ def run(args: argparse.Namespace) -> dict[str, Any]:
             "baseline_overlay": overlay_evidence,
             "inventory": inventory,
             "rendered": rendered_contracts[0],
+        },
+        "site006v": {
+            "candidate": {
+                **theme_input,
+                "installed": theme_provenance,
+                "theme_commit": site006v_validation.THEME_COMMIT,
+            },
+            "output": theme_outputs[0],
+            "presentation_changes": {
+                "approved_title_separator": " — ",
+                "baseline_title_overrides": EXPECTED_TITLE_OVERRIDES,
+                "legacy_presentation_selectors_required": False,
+            },
         },
         "warning_ledger": publication["warning_ledger"],
     }
@@ -908,7 +932,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         return 1
     counts = evidence["counts"]
     print(
-        "SITE-002V validation passed twice: "
+        "SITE-006V validation passed twice: "
         f"{counts['markdown']} Markdown + {counts['notebooks']} notebooks = "
         f"{counts['articles']} articles; {len(evidence['negative_gates'])} negative gates"
     )

--- a/migration/site003/README.md
+++ b/migration/site003/README.md
@@ -31,6 +31,13 @@ stronger outdated-content warning; `refresh` and `keep` receive no notice.
 Canonical URLs are deterministically `https://nekrasovp.ru` plus the manifest
 route.
 
+SITE-006V keeps those semantic requirements while replacing the vendored
+theme's brittle presentation selectors. The validator accepts the reviewed
+em-dash title separator, reads the site-owned language marker, requires the
+packaged theme's public `.pet-prose` article and `.pet-content-status--*`
+notice contracts, and does not require `.article-language`, `.content-notice`,
+or `article[data-content-status]`.
+
 ## Validation
 
 Run from the repository root on Python 3.12:
@@ -42,7 +49,7 @@ uv sync --locked --all-groups
 ./scripts/site test
 uv run --locked --all-groups ruff check \
   migration/site_build migration/site002v/validate.py migration/site003 \
-  plugins/site_metadata.py
+  migration/site006v plugins/site_metadata.py
 ```
 
 `./scripts/site validate` reuses the SITE-002V harness for two clean locked

--- a/migration/site003/validate.py
+++ b/migration/site003/validate.py
@@ -421,7 +421,7 @@ def validate_output(
                 row.source,
                 f"html lang expected={row.language!r} actual={html_lang!r}",
             )
-        expected_title = f"{row.title} - {SITENAME}"
+        expected_title = f"{row.title} — {SITENAME}"
         rendered_title = soup.title.get_text(strip=True) if soup.title else None
         if rendered_title != expected_title:
             raise RenderedContractMismatch(
@@ -436,17 +436,15 @@ def validate_output(
                 f"canonical expected={expected_canonical!r} actual={canonical!r}",
             )
 
-        article = soup.find("article", attrs={"data-content-status": True})
-        rendered_status = article.get("data-content-status") if article else None
-        if rendered_status != row.status:
+        articles = soup.select("article.pet-prose")
+        if len(articles) != 1:
             raise RenderedContractMismatch(
-                row.source,
-                f"status expected={row.status!r} actual={rendered_status!r}",
+                row.source, "expected one packaged-theme semantic article"
             )
 
-        labels = soup.select(".article-language[data-language-code]")
+        labels = soup.select("[data-site-language-code]")
         expected_label = LANGUAGE_LABELS[row.language]
-        if len(labels) != 1 or labels[0].get("data-language-code") != row.language:
+        if len(labels) != 1 or labels[0].get("data-site-language-code") != row.language:
             raise RenderedContractMismatch(row.source, "expected exactly one language label")
         label_text = " ".join(labels[0].get_text(" ", strip=True).split())
         if label_text != expected_label:
@@ -456,12 +454,28 @@ def validate_output(
             )
         label_counts[row.language] += 1
 
-        notices = soup.select(".content-notice[data-content-status]")
+        notices = soup.select(".pet-content-status[data-content-status]")
         if row.status in {"archive", "deprecated"}:
             if len(notices) != 1 or notices[0].get("data-content-status") != row.status:
                 raise RenderedContractMismatch(row.source, "expected one status-specific notice")
+            expected_class = f"pet-content-status--{row.status}"
+            if expected_class not in notices[0].get("class", []):
+                raise RenderedContractMismatch(
+                    row.source, f"notice does not use public class {expected_class!r}"
+                )
             notice_counts[row.status] += 1
             notice_text = " ".join(notices[0].get_text(" ", strip=True).split())
+            expected_notice_token = (
+                "Исторический материал"
+                if row.status == "archive" and row.language == "ru"
+                else "historical record"
+                if row.status == "archive"
+                else "outdated or unsafe guidance"
+            )
+            if expected_notice_token.casefold() not in notice_text.casefold():
+                raise RenderedContractMismatch(
+                    row.source, "status notice lost its user-visible meaning"
+                )
         else:
             if notices:
                 raise RenderedContractMismatch(

--- a/migration/site006v/README.md
+++ b/migration/site006v/README.md
@@ -1,0 +1,25 @@
+# Immutable theme candidate integration (SITE-006V)
+
+The active Pelican theme is the unpublished `pelican-engineering-theme` 0.1.0
+candidate installed from the exact merged Git commit
+`027a170ac6c8288347de5353569a089c526afae2`. The full VCS requirement is locked
+in `uv.lock`; this is validation evidence, not a public release claim.
+
+`pelicanconf.py` obtains `THEME` only from the distribution's public
+`get_theme_path()` API. Site-owned templates live under `templates/`, extend
+the installed `!theme/...` namespace, and are restricted to the documented 18
+public blocks. The historical vendored `theme/` directory remains in the tree
+for rollback but is neither configured nor copied into generated output.
+
+The shared `./scripts/site validate` gate creates an external locked
+environment, records PEP 610 `direct_url.json`, distribution version,
+`site-packages` paths, lock source and commit, then compares normalized route,
+metadata, asset, runtime-reference, and theme-identity evidence across two
+clean full-corpus builds. SITE-003 continues to require all 46 legacy routes,
+35 Markdown sources, 11 notebooks, lifecycle counts `9/13/16/8`, language
+counts `42 en / 4 ru`, notices, labels, canonicals, and no-execution behavior.
+
+The SITE-003 rendered validator now follows the candidate's approved em-dash
+title separator and public semantic notice/article classes. It no longer
+depends on the legacy `.article-language`, `.content-notice`, or
+`article[data-content-status]` presentation selectors.

--- a/migration/site006v/__init__.py
+++ b/migration/site006v/__init__.py
@@ -1,0 +1,1 @@
+"""SITE-006V immutable theme validation package."""

--- a/migration/site006v/browser_validate.py
+++ b/migration/site006v/browser_validate.py
@@ -1,0 +1,552 @@
+"""Run the local SITE-006V browser matrix against generated static output."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import mimetypes
+import re
+import subprocess
+from importlib.metadata import version
+from pathlib import Path, PurePosixPath
+from typing import Any
+from urllib.parse import unquote, urlparse
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+THEME_COMMIT = "027a170ac6c8288347de5353569a089c526afae2"
+ROUTES = {
+    "archive": "archives.html",
+    "article": "python-gil.html",
+    "index": "index.html",
+    "notebook": "number-sequences.html",
+    "page": "pages/about.html",
+}
+WIDE_TABLE_ROUTE = "stock-data-with-pandas-datareader.html"
+VIEWPORTS = {
+    "desktop": {"width": 1440, "height": 1000},
+    "mobile": {"width": 390, "height": 844},
+}
+AXE_CONTENT_LEDGER = {
+    "notebook:mobile:dark": {"incomplete": {"color-contrast": 3}, "violations": {}},
+    "notebook:mobile:light": {"incomplete": {"color-contrast": 3}, "violations": {}},
+    "page:desktop:dark": {"incomplete": {}, "violations": {"heading-order": 1}},
+    "page:desktop:light": {"incomplete": {}, "violations": {"heading-order": 1}},
+    "page:mobile:dark": {"incomplete": {}, "violations": {"heading-order": 1}},
+    "page:mobile:light": {"incomplete": {}, "violations": {"heading-order": 1}},
+    "wide_table:desktop:light": {
+        "incomplete": {"color-contrast": 6},
+        "violations": {},
+    },
+    "wide_table:mobile:light": {
+        "incomplete": {"color-contrast": 99},
+        "violations": {},
+    },
+}
+ZERO_AXE_FINDINGS = {"incomplete": {}, "violations": {}}
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _git(*arguments: str) -> str:
+    result = subprocess.run(
+        ["git", *arguments],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode:
+        raise RuntimeError(result.stderr.strip())
+    return result.stdout.strip()
+
+
+def _safe_output_file(output_root: Path, url_path: str) -> Path | None:
+    decoded = unquote(url_path)
+    relative = PurePosixPath(decoded.lstrip("/") or "index.html")
+    if relative.is_absolute() or ".." in relative.parts:
+        return None
+    if decoded.endswith("/"):
+        relative = relative / "index.html"
+    candidate = output_root.joinpath(*relative.parts)
+    return candidate if candidate.is_file() else None
+
+
+def _install_local_routes(context: Any, output_root: Path, network: dict[str, Any]) -> None:
+    def handle(route: Any) -> None:
+        url = route.request.url
+        parsed = urlparse(url)
+        if parsed.hostname != "nekrasovp.ru":
+            network["external"].append(url)
+            route.abort()
+            return
+        candidate = _safe_output_file(output_root, parsed.path)
+        if candidate is None:
+            network["missing_same_origin"].append(url)
+            route.abort()
+            return
+        content_type = mimetypes.guess_type(candidate.name)[0] or "application/octet-stream"
+        network["fulfilled_same_origin"].append(url)
+        route.fulfill(
+            status=200,
+            body=candidate.read_bytes(),
+            content_type=content_type,
+        )
+
+    context.route("**/*", handle)
+
+
+def _assert_layout(page: Any, *, notebook_mobile: bool) -> dict[str, Any]:
+    layout = page.evaluate(
+        """() => ({
+          documentWidth: document.documentElement.scrollWidth,
+          mainCount: document.querySelectorAll('main#main-content[tabindex="-1"]').length,
+          viewportWidth: window.innerWidth,
+          overflowingOutputs: [...document.querySelectorAll('.output_html')]
+            .filter(element => element.scrollWidth > element.clientWidth + 1).length,
+          wideTableScrollers: document.querySelectorAll(
+            '[data-pet-table-scroller="true"][role="region"][tabindex="0"]'
+          ).length
+        })"""
+    )
+    if layout["mainCount"] != 1:
+        raise RuntimeError(f"browser lost the one semantic main target: {layout!r}")
+    if layout["documentWidth"] > layout["viewportWidth"] + 1:
+        raise RuntimeError(f"page-level horizontal overflow: {layout!r}")
+    if notebook_mobile and (
+        layout["wideTableScrollers"] < 1 or layout["overflowingOutputs"] < 1
+    ):
+        raise RuntimeError(f"mobile notebook has no accessible wide-table scroller: {layout!r}")
+    return layout
+
+
+def _keyboard_case(page: Any) -> dict[str, Any]:
+    page.evaluate("document.activeElement.blur()")
+    page.keyboard.press("Tab")
+    first = page.evaluate(
+        """() => ({
+          className: document.activeElement.className,
+          tagName: document.activeElement.tagName
+        })"""
+    )
+    if "pet-skip-link" not in str(first["className"]):
+        raise RuntimeError(f"skip link is not the first keyboard target: {first!r}")
+    focus_order = []
+    for _ in range(20):
+        page.keyboard.press("Tab")
+        current = page.evaluate(
+            """() => ({
+              ariaLabel: document.activeElement.getAttribute('aria-label'),
+              className: document.activeElement.className,
+              tagName: document.activeElement.tagName,
+              text: (document.activeElement.textContent || '').trim().slice(0, 80)
+            })"""
+        )
+        focus_order.append(current)
+        if "pet-theme-toggle" in str(current["className"]):
+            break
+    if not any("pet-theme-toggle" in str(item["className"]) for item in focus_order):
+        raise RuntimeError("theme toggle is not keyboard reachable")
+
+    page.locator(".pet-skip-link").focus()
+    page.keyboard.press("Enter")
+    page.wait_for_timeout(50)
+    skip_target = page.evaluate("document.activeElement.id")
+    if skip_target != "main-content":
+        raise RuntimeError(f"skip link did not focus main-content: {skip_target!r}")
+    return {"first": first, "focus_order": focus_order, "skip_target": skip_target}
+
+
+def _axe(
+    page: Any,
+    axe_script: Path,
+    *,
+    expected: dict[str, dict[str, int]],
+) -> dict[str, Any]:
+    page.add_script_tag(path=str(axe_script))
+    result = page.evaluate(
+        """async () => {
+          const report = await axe.run(document, {
+            resultTypes: ['violations', 'incomplete']
+          });
+          const slim = item => ({
+            id: item.id,
+            impact: item.impact,
+            nodes: item.nodes.length
+          });
+          return {
+            incomplete: report.incomplete.map(slim),
+            passes: report.passes.length,
+            violations: report.violations.map(slim)
+          };
+        }"""
+    )
+    observed = {
+        category: {item["id"]: item["nodes"] for item in result[category]}
+        for category in ("incomplete", "violations")
+    }
+    if observed != expected:
+        raise RuntimeError(
+            f"axe finding ledger mismatch: expected={expected!r} observed={observed!r}"
+        )
+    result["content_owned_findings"] = observed
+    return result
+
+
+def _screenshot(page: Any, artifact_root: Path, name: str) -> dict[str, Any]:
+    path = artifact_root / f"{name}.png"
+    page.screenshot(path=str(path), full_page=False)
+    return {
+        "path": path.name,
+        "sha256": _sha256(path),
+        "size": path.stat().st_size,
+    }
+
+
+def _theme_case(
+    browser: Any,
+    *,
+    artifact_root: Path,
+    axe_script: Path,
+    output_root: Path,
+    route_name: str,
+    route_path: str,
+    viewport_name: str,
+    viewport: dict[str, int],
+    expect_wide_table: bool = False,
+) -> dict[str, Any]:
+    network = {"external": [], "fulfilled_same_origin": [], "missing_same_origin": []}
+    context = browser.new_context(viewport=viewport)
+    _install_local_routes(context, output_root, network)
+    page = context.new_page()
+    page.goto(f"https://nekrasovp.ru/{route_path}", wait_until="networkidle")
+    light = page.evaluate(
+        """() => {
+          const toggle = document.querySelector('[data-pet-theme-toggle]');
+          return {
+            ariaPressed: toggle.getAttribute('aria-pressed'),
+            stored: localStorage.getItem('pelican-engineering-theme'),
+            theme: document.documentElement.dataset.theme || 'light',
+            toggleHidden: toggle.hidden
+          };
+        }"""
+    )
+    if light != {
+        "ariaPressed": "false",
+        "stored": None,
+        "theme": "light",
+        "toggleHidden": False,
+    }:
+        raise RuntimeError(f"first-visit light contract failed: {light!r}")
+    layout_light = _assert_layout(
+        page,
+        notebook_mobile=expect_wide_table and viewport_name == "mobile",
+    )
+    keyboard = _keyboard_case(page)
+    axe_light = _axe(
+        page,
+        axe_script,
+        expected=AXE_CONTENT_LEDGER.get(
+            f"{route_name}:{viewport_name}:light", ZERO_AXE_FINDINGS
+        ),
+    )
+    light_shot = _screenshot(
+        page, artifact_root, f"{route_name}-{viewport_name}-light"
+    )
+
+    page.locator("[data-pet-theme-toggle]").click()
+    page.reload(wait_until="networkidle")
+    dark = page.evaluate(
+        """() => {
+          const toggle = document.querySelector('[data-pet-theme-toggle]');
+          return {
+            ariaPressed: toggle.getAttribute('aria-pressed'),
+            earlyMark: performance.getEntriesByName('pet-theme-applied').length,
+            stored: localStorage.getItem('pelican-engineering-theme'),
+            theme: document.documentElement.dataset.theme || 'light'
+          };
+        }"""
+    )
+    if (
+        dark["ariaPressed"] != "true"
+        or dark["stored"] != "dark"
+        or dark["theme"] != "dark"
+        or dark["earlyMark"] < 1
+    ):
+        raise RuntimeError(f"persisted dark contract failed: {dark!r}")
+    layout_dark = _assert_layout(
+        page,
+        notebook_mobile=expect_wide_table and viewport_name == "mobile",
+    )
+    axe_dark = _axe(
+        page,
+        axe_script,
+        expected=AXE_CONTENT_LEDGER.get(
+            f"{route_name}:{viewport_name}:dark", ZERO_AXE_FINDINGS
+        ),
+    )
+    dark_shot = _screenshot(page, artifact_root, f"{route_name}-{viewport_name}-dark")
+    context.close()
+    if network["external"] or network["missing_same_origin"]:
+        raise RuntimeError(f"network boundary failed: {network!r}")
+    return {
+        "axe_dark": axe_dark,
+        "axe_light": axe_light,
+        "dark": dark,
+        "keyboard": keyboard,
+        "layout_dark": layout_dark,
+        "layout_light": layout_light,
+        "light": light,
+        "network": {
+            "external": [],
+            "fulfilled_same_origin": len(network["fulfilled_same_origin"]),
+            "missing_same_origin": [],
+        },
+        "screenshots": [light_shot, dark_shot],
+    }
+
+
+def _no_javascript_case(
+    browser: Any,
+    *,
+    artifact_root: Path,
+    output_root: Path,
+    route_name: str,
+    route_path: str,
+    viewport_name: str,
+    viewport: dict[str, int],
+    expect_wide_table: bool = False,
+) -> dict[str, Any]:
+    network = {"external": [], "fulfilled_same_origin": [], "missing_same_origin": []}
+    context = browser.new_context(viewport=viewport, java_script_enabled=False)
+    _install_local_routes(context, output_root, network)
+    page = context.new_page()
+    page.goto(f"https://nekrasovp.ru/{route_path}", wait_until="networkidle")
+    fallback = page.locator("html").get_attribute("data-theme")
+    if fallback is not None or page.locator("[data-pet-theme-toggle]").is_visible():
+        raise RuntimeError("no-JavaScript page did not retain the light hidden-toggle fallback")
+    layout = _assert_layout(page, notebook_mobile=False)
+    if (
+        expect_wide_table
+        and viewport_name == "mobile"
+        and layout["overflowingOutputs"] < 1
+    ):
+        raise RuntimeError(f"no-JavaScript wide table is not locally scrollable: {layout!r}")
+    page.keyboard.press("Tab")
+    if "pet-skip-link" not in str(page.locator(":focus").get_attribute("class")):
+        raise RuntimeError("no-JavaScript skip link is not keyboard reachable")
+    screenshot = _screenshot(page, artifact_root, f"{route_name}-{viewport_name}-nojs")
+    context.close()
+    if network["external"] or network["missing_same_origin"]:
+        raise RuntimeError(f"no-JavaScript network boundary failed: {network!r}")
+    return {
+        "layout": layout,
+        "light_fallback": True,
+        "network": {
+            "external": [],
+            "fulfilled_same_origin": len(network["fulfilled_same_origin"]),
+            "missing_same_origin": [],
+        },
+        "screenshot": screenshot,
+        "skip_link_keyboard_reachable": True,
+        "theme_toggle_hidden": True,
+    }
+
+
+def _print_case(
+    browser: Any,
+    *,
+    artifact_root: Path,
+    output_root: Path,
+    route_name: str,
+    route_path: str,
+) -> dict[str, Any]:
+    network = {"external": [], "fulfilled_same_origin": [], "missing_same_origin": []}
+    context = browser.new_context(viewport=VIEWPORTS["desktop"])
+    context.add_init_script(
+        "localStorage.setItem('pelican-engineering-theme', 'dark')"
+    )
+    _install_local_routes(context, output_root, network)
+    page = context.new_page()
+    page.emulate_media(media="print")
+    page.goto(f"https://nekrasovp.ru/{route_path}", wait_until="networkidle")
+    colors = page.evaluate(
+        """() => ({
+          background: getComputedStyle(document.body).backgroundColor,
+          color: getComputedStyle(document.body).color,
+          documentWidth: document.documentElement.scrollWidth,
+          viewportWidth: window.innerWidth
+        })"""
+    )
+    if colors["background"] == "rgb(16, 23, 18)":
+        raise RuntimeError(f"print retained the dark background: {colors!r}")
+    if colors["documentWidth"] > colors["viewportWidth"] + 1:
+        raise RuntimeError(f"print surface overflows the viewport: {colors!r}")
+    screenshot = _screenshot(page, artifact_root, f"{route_name}-desktop-print")
+    context.close()
+    if network["external"] or network["missing_same_origin"]:
+        raise RuntimeError(f"print network boundary failed: {network!r}")
+    return {"computed": colors, "light_print": True, "screenshot": screenshot}
+
+
+def run(args: argparse.Namespace) -> dict[str, Any]:
+    try:
+        from playwright.sync_api import sync_playwright
+    except ImportError as error:
+        raise RuntimeError("install the locked theme development environment") from error
+
+    output_root = args.output_root.resolve()
+    artifact_root = args.artifact_root.resolve()
+    axe_script = args.axe_script.resolve()
+    if not output_root.is_dir() or not axe_script.is_file():
+        raise RuntimeError("generated output or local axe-core script is unavailable")
+    artifact_root.mkdir(parents=True, exist_ok=True)
+    for route in ROUTES.values():
+        if not (output_root / route).is_file():
+            raise RuntimeError(f"representative route is missing: {route}")
+    if not (output_root / WIDE_TABLE_ROUTE).is_file():
+        raise RuntimeError(f"wide-table route is missing: {WIDE_TABLE_ROUTE}")
+
+    cases: dict[str, Any] = {}
+    no_javascript: dict[str, Any] = {}
+    wide_table: dict[str, Any] = {}
+    wide_table_no_javascript: dict[str, Any] = {}
+    with sync_playwright() as playwright:
+        browser = playwright.chromium.launch()
+        browser_version = browser.version
+        for route_name, route_path in ROUTES.items():
+            for viewport_name, viewport in VIEWPORTS.items():
+                key = f"{route_name}:{viewport_name}"
+                cases[key] = _theme_case(
+                    browser,
+                    artifact_root=artifact_root,
+                    axe_script=axe_script,
+                    output_root=output_root,
+                    route_name=route_name,
+                    route_path=route_path,
+                    viewport_name=viewport_name,
+                    viewport=viewport,
+                )
+                no_javascript[key] = _no_javascript_case(
+                    browser,
+                    artifact_root=artifact_root,
+                    output_root=output_root,
+                    route_name=route_name,
+                    route_path=route_path,
+                    viewport_name=viewport_name,
+                    viewport=viewport,
+                )
+        for viewport_name, viewport in VIEWPORTS.items():
+            wide_table[viewport_name] = _theme_case(
+                browser,
+                artifact_root=artifact_root,
+                axe_script=axe_script,
+                output_root=output_root,
+                route_name="wide_table",
+                route_path=WIDE_TABLE_ROUTE,
+                viewport_name=viewport_name,
+                viewport=viewport,
+                expect_wide_table=True,
+            )
+            wide_table_no_javascript[viewport_name] = _no_javascript_case(
+                browser,
+                artifact_root=artifact_root,
+                output_root=output_root,
+                route_name="wide_table",
+                route_path=WIDE_TABLE_ROUTE,
+                viewport_name=viewport_name,
+                viewport=viewport,
+                expect_wide_table=True,
+            )
+        print_cases = {
+            name: _print_case(
+                browser,
+                artifact_root=artifact_root,
+                output_root=output_root,
+                route_name=name,
+                route_path=ROUTES[name],
+            )
+            for name in ("article", "notebook")
+        }
+        print_cases["wide_table"] = _print_case(
+            browser,
+            artifact_root=artifact_root,
+            output_root=output_root,
+            route_name="wide_table",
+            route_path=WIDE_TABLE_ROUTE,
+        )
+        browser.close()
+
+    screenshots = sorted(artifact_root.glob("*.png"))
+    report = {
+        "axe_core": re.search(r"axe v([0-9.]+)", axe_script.read_text(errors="ignore"))[1],
+        "axe_content_ledger": AXE_CONTENT_LEDGER,
+        "cases": cases,
+        "chromium": browser_version,
+        "contract": "nekrasovp-site006v-browser.v1",
+        "no_javascript": no_javascript,
+        "playwright": version("playwright"),
+        "print": print_cases,
+        "routes": ROUTES,
+        "screenshots": [
+            {
+                "path": path.name,
+                "sha256": _sha256(path),
+                "size": path.stat().st_size,
+            }
+            for path in screenshots
+        ],
+        "source_head": _git("rev-parse", "HEAD"),
+        "source_status": _git("status", "--porcelain=v1", "--untracked-files=all"),
+        "technical_evidence_not_human_acceptance": True,
+        "theme_commit": THEME_COMMIT,
+        "totals": {
+            "axe_scans": (len(cases) + len(wide_table)) * 2,
+            "browser_cases": len(cases) + len(wide_table),
+            "external_requests": 0,
+            "no_javascript_cases": len(no_javascript) + len(wide_table_no_javascript),
+            "print_cases": len(print_cases),
+            "screenshots": len(screenshots),
+        },
+        "wide_table": {
+            "cases": wide_table,
+            "no_javascript": wide_table_no_javascript,
+            "route": WIDE_TABLE_ROUTE,
+        },
+    }
+    report_path = artifact_root / "report.json"
+    report_path.write_text(
+        json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return report
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser(description=__doc__)
+    result.add_argument("--output-root", type=Path, required=True)
+    result.add_argument("--artifact-root", type=Path, required=True)
+    result.add_argument("--axe-script", type=Path, required=True)
+    return result
+
+
+def main() -> int:
+    try:
+        report = run(parser().parse_args())
+    except Exception as error:
+        print(f"SITE-006V browser validation failed: {error}")
+        return 1
+    print(
+        "SITE-006V browser validation passed: "
+        f"{report['totals']['browser_cases']} light/dark/persistence/keyboard cases, "
+        f"{report['totals']['no_javascript_cases']} no-JavaScript cases, "
+        f"{report['totals']['axe_scans']} axe scans, "
+        f"{report['totals']['print_cases']} print cases, zero external requests"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/migration/site006v/validate.py
+++ b/migration/site006v/validate.py
@@ -1,0 +1,394 @@
+"""Validate the immutable installed-theme and generated-output boundaries."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import subprocess
+import tomllib
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+from bs4 import BeautifulSoup
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+THEME_COMMIT = "027a170ac6c8288347de5353569a089c526afae2"
+THEME_REPOSITORY = "https://github.com/nekrasovp/pelican-engineering-theme.git"
+THEME_REQUIREMENT = (
+    "pelican-engineering-theme @ "
+    f"git+{THEME_REPOSITORY}@{THEME_COMMIT}"
+)
+PUBLIC_BLOCKS = {
+    "body_class",
+    "body_end",
+    "body_start",
+    "canonical",
+    "content",
+    "content_footer",
+    "content_header",
+    "head_meta",
+    "head_styles",
+    "hero",
+    "html_head",
+    "page_class",
+    "scripts",
+    "site_footer",
+    "site_header",
+    "site_navigation",
+    "structured_data",
+    "title",
+}
+LEGACY_ASSET_TOKENS = (
+    "addthis",
+    "bootstrap",
+    "disqus",
+    "font-awesome",
+    "fontawesome",
+    "jquery",
+    "shariff",
+    "tipuesearch",
+)
+REQUIRED_THEME_ASSETS = {
+    "theme/css/scaffold.css",
+    "theme/js/theme.js",
+}
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _run(command: list[str], *, cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command,
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _require_success(result: subprocess.CompletedProcess[str], label: str) -> None:
+    if result.returncode:
+        raise RuntimeError(
+            f"{label} failed with exit {result.returncode}:\n"
+            f"{result.stdout}{result.stderr}"
+        )
+
+
+def _lock_source() -> str:
+    lock = tomllib.loads((REPO_ROOT / "uv.lock").read_text(encoding="utf-8"))
+    matches = [
+        package
+        for package in lock["package"]
+        if package["name"] == "pelican-engineering-theme"
+    ]
+    if len(matches) != 1:
+        raise RuntimeError("uv.lock must contain exactly one pelican-engineering-theme")
+    source = matches[0].get("source", {}).get("git")
+    if not isinstance(source, str):
+        raise RuntimeError("pelican-engineering-theme lock source is not Git")
+    if f"rev={THEME_COMMIT}" not in source or not source.endswith(f"#{THEME_COMMIT}"):
+        raise RuntimeError("theme lock source does not resolve the exact full commit")
+    if "branch=" in source or "tag=" in source:
+        raise RuntimeError("theme lock source contains a floating branch or tag")
+    return source
+
+
+def _template_boundary() -> dict[str, Any]:
+    templates = REPO_ROOT / "templates"
+    if not templates.is_dir():
+        raise RuntimeError("site-owned theme override directory is missing")
+    records = []
+    for template in sorted(templates.glob("*.html")):
+        source = template.read_text(encoding="utf-8")
+        parent = re.search(r'{%\s+extends\s+"(!theme/[a-z_]+\.html)"\s+%}', source)
+        if not parent:
+            raise RuntimeError(f"{template.name} does not extend the !theme namespace")
+        blocks = sorted(set(re.findall(r"{%\s+block\s+([a-z_]+)", source)))
+        unsupported = sorted(set(blocks) - PUBLIC_BLOCKS)
+        if not blocks or unsupported:
+            raise RuntimeError(
+                f"{template.name} has invalid public blocks: unsupported={unsupported!r}"
+            )
+        records.append(
+            {
+                "blocks": blocks,
+                "path": template.relative_to(REPO_ROOT).as_posix(),
+                "theme_parent": parent.group(1),
+            }
+        )
+    if not records:
+        raise RuntimeError("site-owned override boundary contains no HTML templates")
+    return {
+        "documented_public_blocks": sorted(PUBLIC_BLOCKS),
+        "public_block_count": len(PUBLIC_BLOCKS),
+        "templates": records,
+    }
+
+
+def verify_dependency_input() -> dict[str, Any]:
+    """Reject local, copied, PyPI, tag, branch, or relative theme inputs."""
+
+    project = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    dependencies = project["project"]["dependencies"]
+    if dependencies.count(THEME_REQUIREMENT) != 1:
+        raise RuntimeError("pyproject.toml does not contain the one exact theme requirement")
+    config = (REPO_ROOT / "pelicanconf.py").read_text(encoding="utf-8")
+    markdown = (REPO_ROOT / "migration/site_build/markdownconf.py").read_text(
+        encoding="utf-8"
+    )
+    if "from pelican_engineering_theme import get_theme_path" not in config:
+        raise RuntimeError("Pelican configuration does not import the public theme API")
+    if "THEME = str(get_theme_path())" not in config:
+        raise RuntimeError("Pelican THEME is not obtained through get_theme_path()")
+    if "THEME_TEMPLATES_OVERRIDES" not in config:
+        raise RuntimeError("site-owned theme override boundary is not configured")
+    if 'THEME = \'theme\'' in config or 'REPO_ROOT / "theme"' in markdown:
+        raise RuntimeError("the vendored theme remains configured as active")
+    vendored = REPO_ROOT / "theme"
+    if not (vendored / "templates/base.html").is_file():
+        raise RuntimeError("rollback-only vendored theme was unexpectedly deleted")
+    return {
+        "direct_requirement": THEME_REQUIREMENT,
+        "lock_source": _lock_source(),
+        "override_boundary": _template_boundary(),
+        "vendored_theme_present": True,
+        "vendored_theme_configured": False,
+    }
+
+
+def installed_provenance(python: Path) -> dict[str, Any]:
+    """Prove that the active theme is the exact installed VCS distribution."""
+
+    probe_code = r'''
+import importlib.metadata as metadata
+import json
+import runpy
+import sys
+from pathlib import Path
+
+import pelican_engineering_theme
+from pelican_engineering_theme import get_theme_path
+
+distribution = metadata.distribution("pelican-engineering-theme")
+direct_url_text = distribution.read_text("direct_url.json")
+if direct_url_text is None:
+    raise RuntimeError("installed distribution has no direct_url.json")
+settings = runpy.run_path(sys.argv[1])
+print(json.dumps({
+    "active_theme": settings["THEME"],
+    "direct_url": json.loads(direct_url_text),
+    "distribution_root": str(distribution.locate_file("")),
+    "module_file": str(Path(pelican_engineering_theme.__file__).resolve()),
+    "override_paths": settings["THEME_TEMPLATES_OVERRIDES"],
+    "theme_path": str(get_theme_path()),
+    "version": distribution.version,
+}, sort_keys=True))
+'''
+    probe = _run(
+        [str(python), "-I", "-c", probe_code, str(REPO_ROOT / "publishconf.py")],
+        cwd=REPO_ROOT,
+    )
+    _require_success(probe, "installed theme provenance probe")
+    payload = json.loads(probe.stdout)
+    direct_url = payload["direct_url"]
+    vcs = direct_url.get("vcs_info", {})
+    if vcs.get("vcs") != "git" or vcs.get("commit_id") != THEME_COMMIT:
+        raise RuntimeError(f"installed theme commit provenance is invalid: {direct_url!r}")
+    if vcs.get("requested_revision") != THEME_COMMIT:
+        raise RuntimeError(f"installed theme requested revision is not exact: {direct_url!r}")
+    if direct_url.get("url", "").removeprefix("git+") != THEME_REPOSITORY:
+        raise RuntimeError(f"installed theme repository is invalid: {direct_url!r}")
+    if direct_url.get("dir_info") or direct_url.get("archive_info"):
+        raise RuntimeError(f"installed theme came from a local or archive source: {direct_url!r}")
+
+    theme_path = Path(payload["theme_path"])
+    active_theme = Path(payload["active_theme"])
+    module_file = Path(payload["module_file"])
+    if not theme_path.is_absolute() or not theme_path.is_dir():
+        raise RuntimeError(f"get_theme_path() did not return an absolute directory: {theme_path}")
+    if theme_path != active_theme:
+        raise RuntimeError(f"active THEME differs from get_theme_path(): {active_theme}")
+    if theme_path.is_relative_to(REPO_ROOT.resolve()):
+        raise RuntimeError(f"theme resolved inside the site checkout: {theme_path}")
+    normalized_theme = theme_path.as_posix()
+    normalized_module = module_file.as_posix()
+    marker = "/site-packages/"
+    if marker not in normalized_theme or marker not in normalized_module:
+        raise RuntimeError("theme module and resources must resolve under site-packages")
+    expected_overrides = [str((REPO_ROOT / "templates").resolve())]
+    observed_overrides = [str(Path(path).resolve()) for path in payload["override_paths"]]
+    if observed_overrides != expected_overrides:
+        raise RuntimeError(
+            f"unexpected THEME_TEMPLATES_OVERRIDES: {observed_overrides!r}"
+        )
+    return {
+        "active_theme_matches_public_api": True,
+        "commit_id": vcs["commit_id"],
+        "direct_url": direct_url,
+        "distribution_root": (
+            "site-packages/" + payload["distribution_root"].split(marker, 1)[-1]
+            if marker in payload["distribution_root"]
+            else "site-packages"
+        ),
+        "get_theme_path": "site-packages/" + normalized_theme.split(marker, 1)[1],
+        "import_path": "site-packages/" + normalized_module.split(marker, 1)[1],
+        "outside_source_checkouts": True,
+        "override_path": "site/templates",
+        "requested_revision": vcs["requested_revision"],
+        "version": payload["version"],
+    }
+
+
+def _canonical(soup: BeautifulSoup) -> str | None:
+    for link in soup.find_all("link"):
+        rel = link.get("rel") or []
+        tokens = rel if isinstance(rel, list) else str(rel).split()
+        if "canonical" in {str(token).casefold() for token in tokens}:
+            href = link.get("href")
+            return str(href) if href is not None else None
+    return None
+
+
+def _urls_for(
+    soup: BeautifulSoup, selectors: tuple[tuple[str, str], ...]
+) -> list[str]:
+    values: list[str] = []
+    for selector, attribute in selectors:
+        for element in soup.select(selector):
+            value = element.get(attribute)
+            if value:
+                values.append(str(value))
+    return values
+
+
+def output_evidence(output_root: Path) -> dict[str, Any]:
+    """Collect deterministic routes, metadata, assets, and inactive-theme proof."""
+
+    html_files = sorted(output_root.rglob("*.html"))
+    if not html_files:
+        raise RuntimeError("generated output contains no HTML")
+    metadata: list[dict[str, Any]] = []
+    active_urls: set[str] = set()
+    content_media_urls: set[str] = set()
+    external_runtime: set[str] = set()
+    legacy_references: set[str] = set()
+    for path in html_files:
+        route = path.relative_to(output_root).as_posix()
+        text = path.read_text(encoding="utf-8")
+        soup = BeautifulSoup(text, "html.parser")
+        if not soup.select_one("script[data-pet-theme-loader]"):
+            raise RuntimeError(f"{route} does not use the packaged theme loader")
+        body = soup.find("body")
+        if not body or "pet-shell" not in (body.get("class") or []):
+            raise RuntimeError(f"{route} does not use the packaged theme shell")
+        if len(soup.select('main#main-content[tabindex="-1"]')) != 1:
+            raise RuntimeError(f"{route} lost the one focusable main target")
+        html = soup.find("html")
+        metadata.append(
+            {
+                "canonical": _canonical(soup),
+                "language": html.get("lang") if html else None,
+                "route": route,
+                "title": soup.title.get_text(strip=True) if soup.title else None,
+            }
+        )
+        runtime_urls = _urls_for(
+            soup,
+            (
+                ("script[src]", "src"),
+                ('link[rel~="stylesheet"][href]', "href"),
+                ("iframe[src]", "src"),
+            ),
+        )
+        media_urls = _urls_for(
+            soup,
+            (
+                ("img[src]", "src"),
+                ("source[src]", "src"),
+                ("video[src]", "src"),
+                ("audio[src]", "src"),
+            ),
+        )
+        for value in runtime_urls:
+            active_urls.add(value)
+            lowered = value.casefold()
+            if any(token in lowered for token in LEGACY_ASSET_TOKENS):
+                legacy_references.add(value)
+            parsed = urlparse(value if not value.startswith("//") else "https:" + value)
+            if parsed.scheme in {"http", "https"} and parsed.netloc != "nekrasovp.ru":
+                external_runtime.add(value)
+        for value in media_urls:
+            lowered = value.casefold()
+            if any(token in lowered for token in LEGACY_ASSET_TOKENS):
+                legacy_references.add(value)
+            parsed = urlparse(value if not value.startswith("//") else "https:" + value)
+            if parsed.scheme in {"http", "https"} and parsed.netloc != "nekrasovp.ru":
+                content_media_urls.add(value)
+
+    if external_runtime:
+        raise RuntimeError(
+            f"generated HTML has external active runtime URLs: {sorted(external_runtime)!r}"
+        )
+    if legacy_references:
+        raise RuntimeError(
+            f"generated HTML references inactive legacy assets: {sorted(legacy_references)!r}"
+        )
+
+    assets = []
+    legacy_asset_files = []
+    for path in sorted(output_root.rglob("*")):
+        if not path.is_file() or path.suffix.casefold() in {".html", ".xml"}:
+            continue
+        relative = path.relative_to(output_root).as_posix()
+        lowered = relative.casefold()
+        if any(token in lowered for token in LEGACY_ASSET_TOKENS):
+            legacy_asset_files.append(relative)
+        assets.append(
+            {
+                "path": relative,
+                "sha256": _sha256(path),
+                "size": path.stat().st_size,
+            }
+        )
+    if legacy_asset_files:
+        raise RuntimeError(f"inactive vendored assets were copied: {legacy_asset_files!r}")
+    asset_paths = {record["path"] for record in assets}
+    if not REQUIRED_THEME_ASSETS <= asset_paths:
+        raise RuntimeError(
+            f"packaged theme assets missing: {sorted(REQUIRED_THEME_ASSETS - asset_paths)!r}"
+        )
+
+    route_payload = "\n".join(record["route"] for record in metadata).encode()
+    metadata_payload = json.dumps(metadata, sort_keys=True, ensure_ascii=False).encode()
+    asset_payload = json.dumps(assets, sort_keys=True, ensure_ascii=False).encode()
+    return {
+        "assets": {
+            "count": len(assets),
+            "records": assets,
+            "sha256": hashlib.sha256(asset_payload).hexdigest(),
+        },
+        "inactive_legacy_theme": {
+            "active_references": [],
+            "copied_assets": [],
+            "vendored_sources_preserved": True,
+        },
+        "metadata": {
+            "records": metadata,
+            "sha256": hashlib.sha256(metadata_payload).hexdigest(),
+        },
+        "runtime": {
+            "active_urls": sorted(active_urls),
+            "external_content_media": sorted(content_media_urls),
+            "external_requests": [],
+        },
+        "routes": {
+            "count": len(metadata),
+            "paths": [record["route"] for record in metadata],
+            "sha256": hashlib.sha256(route_payload).hexdigest(),
+        },
+        "theme_assets": sorted(REQUIRED_THEME_ASSETS),
+    }

--- a/migration/site_build/README.md
+++ b/migration/site_build/README.md
@@ -56,7 +56,11 @@ runs before Pelican and exact rendered metadata validation runs afterward.
 exact installed Git provenance of the notebook reader, runs and gates two clean
 46-article builds, and runs the isolated negative and no-execution cases. It
 also reuses the SITE-003 inventory, preservation, and rendered metadata gates.
-See `migration/site002v/README.md` and `migration/site003/README.md`.
+SITE-006V additionally proves the exact installed theme candidate, public
+`get_theme_path()` and override boundaries, deterministic routes/metadata/
+assets, and the absence of active vendored-theme references. See
+`migration/site002v/README.md`, `migration/site003/README.md`, and
+`migration/site006v/README.md`.
 
 `./scripts/site serve` serves the Markdown-only configuration from the explicit
 `build/local` directory with autoreload. It deliberately uses the same

--- a/migration/site_build/markdownconf.py
+++ b/migration/site_build/markdownconf.py
@@ -10,6 +10,5 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 # ignore is what makes this command an intentionally Markdown-only smoke build.
 MARKUP = ("md",)
 IGNORE_FILES = [*IGNORE_FILES, "*.ipynb"]  # noqa: F405
-THEME = str(REPO_ROOT / "theme")
 PLUGIN_PATHS = [str(REPO_ROOT / "plugins")]
 PLUGINS = ["i18n_subsites", "related_posts", "site_metadata", "tag_cloud"]

--- a/migration/site_build/tests/test_site006v.py
+++ b/migration/site_build/tests/test_site006v.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import re
+import tomllib
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+THEME_COMMIT = "027a170ac6c8288347de5353569a089c526afae2"
+THEME_REPOSITORY = "https://github.com/nekrasovp/pelican-engineering-theme.git"
+THEME_REQUIREMENT = (
+    "pelican-engineering-theme @ "
+    f"git+{THEME_REPOSITORY}@{THEME_COMMIT}"
+)
+PUBLIC_BLOCKS = {
+    "body_class",
+    "body_end",
+    "body_start",
+    "canonical",
+    "content",
+    "content_footer",
+    "content_header",
+    "head_meta",
+    "head_styles",
+    "hero",
+    "html_head",
+    "page_class",
+    "scripts",
+    "site_footer",
+    "site_header",
+    "site_navigation",
+    "structured_data",
+    "title",
+}
+
+
+def test_theme_dependency_is_an_exact_vcs_pin() -> None:
+    project = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    assert project["project"]["dependencies"].count(THEME_REQUIREMENT) == 1
+
+    lock = tomllib.loads((REPO_ROOT / "uv.lock").read_text(encoding="utf-8"))
+    packages = [
+        package
+        for package in lock["package"]
+        if package["name"] == "pelican-engineering-theme"
+    ]
+    assert len(packages) == 1
+    source = packages[0]["source"]["git"]
+    assert f"rev={THEME_COMMIT}" in source
+    assert source.endswith(f"#{THEME_COMMIT}")
+
+
+def test_settings_use_only_the_installed_theme_public_api() -> None:
+    production = (REPO_ROOT / "pelicanconf.py").read_text(encoding="utf-8")
+    markdown = (REPO_ROOT / "migration/site_build/markdownconf.py").read_text(
+        encoding="utf-8"
+    )
+
+    assert "from pelican_engineering_theme import get_theme_path" in production
+    assert "THEME = str(get_theme_path())" in production
+    assert "THEME_TEMPLATES_OVERRIDES" in production
+    assert 'THEME = \'theme\'' not in production
+    assert 'REPO_ROOT / "theme"' not in markdown
+
+
+def test_site_owned_templates_extend_only_the_18_public_blocks() -> None:
+    templates = REPO_ROOT / "templates"
+    assert templates.is_dir()
+    observed_blocks: set[str] = set()
+    for template in templates.glob("*.html"):
+        source = template.read_text(encoding="utf-8")
+        assert re.search(r'{%\s+extends\s+"!theme/[a-z_]+\.html"\s+%}', source)
+        observed_blocks.update(re.findall(r"{%\s+block\s+([a-z_]+)", source))
+
+    assert observed_blocks
+    assert observed_blocks <= PUBLIC_BLOCKS
+    assert len(PUBLIC_BLOCKS) == 18
+
+
+def test_vendored_theme_is_preserved_but_not_active() -> None:
+    assert (REPO_ROOT / "theme/templates/base.html").is_file()
+    assert (REPO_ROOT / "theme/static/js/jquery.min.js").is_file()
+    settings = "\n".join(
+        (
+            (REPO_ROOT / "pelicanconf.py").read_text(encoding="utf-8"),
+            (REPO_ROOT / "migration/site_build/markdownconf.py").read_text(
+                encoding="utf-8"
+            ),
+        )
+    )
+    assert 'THEME = "theme"' not in settings
+    assert "REPO_ROOT / \"theme\"" not in settings
+
+
+def test_browser_matrix_keeps_the_wide_table_case_and_single_focus_label() -> None:
+    browser_validator = (
+        REPO_ROOT / "migration/site006v/browser_validate.py"
+    ).read_text(encoding="utf-8")
+
+    assert browser_validator.count("WIDE_TABLE_ROUTE") >= 6
+    assert browser_validator.count("ariaLabel:") == 1

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -2,6 +2,13 @@
 # -*- coding: utf-8 -*- #
 from __future__ import unicode_literals
 
+from pathlib import Path
+
+from pelican_engineering_theme import get_theme_path
+
+
+REPO_ROOT = Path(__file__).resolve().parent
+
 AUTHOR = 'Nekrasov Pavel'
 SITENAME = 'Data driven'
 SITESUBTITLE = 'Nekrasov Pavel personal page'
@@ -75,11 +82,8 @@ STATIC_PATHS = [
 ]
 
 # Theme path
-THEME = 'theme'
-
-BOOTSTRAP_THEME = 'flatly'
-
-PYGMENTS_STYLE = 'friendly'
+THEME = str(get_theme_path())
+THEME_TEMPLATES_OVERRIDES = [str(REPO_ROOT / 'templates')]
 
 MARKUP = ('md', 'ipynb')
 

--- a/plugins/site_metadata.py
+++ b/plugins/site_metadata.py
@@ -4,6 +4,17 @@ from pelican import signals
 from pelican.contents import Article
 
 LIFECYCLE_STATUSES = {"archive", "deprecated", "keep", "refresh"}
+ARCHIVE_NOTICES = {
+    "en": "This article is preserved as a historical record and may not reflect current practices.",
+    "ru": (
+        "Статья сохранена как исторический материал и может не отражать "
+        "современные практики."
+    ),
+}
+DEPRECATED_WARNING = (
+    "This article is deprecated and may contain outdated or unsafe guidance. "
+    "Verify current documentation before use."
+)
 
 
 def normalize_article_status(content):
@@ -18,6 +29,11 @@ def normalize_article_status(content):
             f"for {content.source_path}"
         )
     content.lifecycle_status = lifecycle_status
+    language = str(getattr(content, "lang", "en")).casefold()
+    if lifecycle_status == "archive":
+        content.archive_notice = ARCHIVE_NOTICES.get(language, ARCHIVE_NOTICES["en"])
+    elif lifecycle_status == "deprecated":
+        content.deprecated_warning = DEPRECATED_WARNING
     content.status = "published"
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "markdown>=3.7,<4",
     "nbconvert>=7.16,<8",
     "pelican>=4.11,<5",
+    "pelican-engineering-theme @ git+https://github.com/nekrasovp/pelican-engineering-theme.git@027a170ac6c8288347de5353569a089c526afae2",
     "pelican-jupyter @ git+https://github.com/nekrasovp/pelican-jupyter.git@137e1eb0ea620f1b15fff0ba81725eea23de1b7a",
     "pillow>=11,<13",
     "six>=1.17,<2",

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,0 +1,6 @@
+# Site-owned theme overrides
+
+This directory is the personal site's `THEME_TEMPLATES_OVERRIDES` boundary.
+Every HTML template must extend the installed `!theme/...` namespace and may
+override only the 18 public blocks documented by `pelican-engineering-theme`.
+Do not copy packaged templates or import from a theme source checkout.

--- a/templates/article.html
+++ b/templates/article.html
@@ -1,0 +1,11 @@
+{% extends "!theme/article.html" %}
+
+{% block content_header %}
+  {{ super() }}
+  <p class="site-content-language">
+    <span data-site-language-code="{{ article.lang | forceescape }}"
+          lang="{{ article.lang | forceescape }}">{% if article.lang == "ru" %}Русский{% else %}English{% endif %}</span>
+  </p>
+{% endblock content_header %}
+
+{% block content %}<div class="entry-content">{{ super() }}</div>{% endblock content %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,66 @@
+{% extends "!theme/base.html" %}
+
+{% block head_meta %}
+  {{ super() }}
+  {% set site_description = pet_content.summary | default('', true) | striptags | trim if pet_content else ENGINEERING_THEME_META_DESCRIPTION | default('', true) %}
+  {% if site_description %}<meta name="description" content="{{ site_description | forceescape }}">{% endif %}
+  {% if article is defined and article.category %}<meta property="article:section" content="{{ article.category | forceescape }}">{% endif %}
+  {% if article is defined %}{% for tag in article.tags %}<meta property="article:tag" content="{{ tag | forceescape }}">{% endfor %}{% endif %}
+{% endblock head_meta %}
+
+{% block head_styles %}
+  {{ super() }}
+  <style data-site-theme-bridge>
+    .site-visually-hidden {
+      clip: rect(0 0 0 0);
+      clip-path: inset(50%);
+      height: 1px;
+      overflow: hidden;
+      position: absolute;
+      white-space: nowrap;
+      width: 1px;
+    }
+
+    @media screen and (max-width: 48rem) {
+      .pet-notebook-document .pet-notebook-region .output_html {
+        contain: layout paint;
+      }
+
+      .pet-notebook-document .pet-notebook-region .output_html table {
+        min-width: 56rem;
+        table-layout: auto;
+      }
+    }
+
+    html[data-theme="dark"] .pet-notebook-region .output_html th,
+    html[data-theme="dark"] .pet-notebook-region .output_html td {
+      background-color: #f7f8f3 !important;
+      color: #151515 !important;
+    }
+
+    @media print {
+      .pet-notebook-document .pet-notebook-region .output_html table {
+        min-width: 0;
+      }
+    }
+  </style>
+{% endblock head_styles %}
+
+{% block scripts %}
+  {{ super() }}
+  <script data-site-notebook-accessibility-bridge>
+    window.addEventListener("DOMContentLoaded", function () {
+      document.querySelectorAll(".pet-notebook-region table th").forEach(function (header) {
+        if (!header.textContent.trim()) {
+          var label = document.createElement("span");
+          label.className = "site-visually-hidden";
+          label.textContent = "Unlabeled table header";
+          header.appendChild(label);
+        }
+      });
+      document.querySelectorAll('[data-pet-table-scroller="true"]').forEach(function (scroller, index) {
+        scroller.setAttribute("aria-label", "Scrollable notebook table output " + (index + 1));
+      });
+    });
+  </script>
+{% endblock scripts %}

--- a/uv.lock
+++ b/uv.lock
@@ -439,6 +439,7 @@ dependencies = [
     { name = "markdown" },
     { name = "nbconvert" },
     { name = "pelican" },
+    { name = "pelican-engineering-theme" },
     { name = "pelican-jupyter" },
     { name = "pillow" },
     { name = "six" },
@@ -460,6 +461,7 @@ requires-dist = [
     { name = "markdown", specifier = ">=3.7,<4" },
     { name = "nbconvert", specifier = ">=7.16,<8" },
     { name = "pelican", specifier = ">=4.11,<5" },
+    { name = "pelican-engineering-theme", git = "https://github.com/nekrasovp/pelican-engineering-theme.git?rev=027a170ac6c8288347de5353569a089c526afae2" },
     { name = "pelican-jupyter", git = "https://github.com/nekrasovp/pelican-jupyter.git?rev=137e1eb0ea620f1b15fff0ba81725eea23de1b7a" },
     { name = "pillow", specifier = ">=11,<13" },
     { name = "six", specifier = ">=1.17,<2" },
@@ -525,6 +527,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c4/8d/da26b77f0d9827d341bdedea357ccb5670717e3a9b4142e3e44c7f34db44/pelican-4.12.0.tar.gz", hash = "sha256:3983b5d2dc84c7bdf967154359077a2b78c0bbd2f7dcc55292133a7779609458", size = 1252907, upload-time = "2026-04-20T15:30:17.322Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6e/55/4adcce41a45f8f77e69d7e84ea447819dae1a78b4b9762a104599e5ec811/pelican-4.12.0-py3-none-any.whl", hash = "sha256:3697230f56cfcca9e98d3ac9ac26f655bb20cad807f7eacf156601e241f69ad8", size = 1358275, upload-time = "2026-04-20T15:30:15.383Z" },
+]
+
+[package.optional-dependencies]
+markdown = [
+    { name = "markdown" },
+]
+
+[[package]]
+name = "pelican-engineering-theme"
+version = "0.1.0"
+source = { git = "https://github.com/nekrasovp/pelican-engineering-theme.git?rev=027a170ac6c8288347de5353569a089c526afae2#027a170ac6c8288347de5353569a089c526afae2" }
+dependencies = [
+    { name = "pelican", extra = ["markdown"] },
 ]
 
 [[package]]


### PR DESCRIPTION
## Scope

- Integrates only SITE-006V from the Pelican unification master plan.
- Pins `nekrasovp/pelican-engineering-theme` to merged candidate commit `027a170ac6c8288347de5353569a089c526afae2` as an immutable VCS dependency.
- Resolves the active theme exclusively through `pelican_engineering_theme.get_theme_path()`.
- Adds site-owned `!theme/...` overrides constrained to the candidate's 18 documented public blocks.
- Preserves the vendored `theme/` tree physically for rollback while proving that it is neither configured nor copied into generated output.
- Updates only brittle presentation expectations (the approved em-dash title separator and candidate public semantic selectors).

Exact PR base: `28d786f6b26d329eab3f79154984399f46af6a24`

Exact PR head: `9331e99f93163776937a972a84629c821b69e009`

## Evidence

RED before implementation:

- The focused SITE-006V regression tests failed 4/4 because the exact VCS dependency, public API configuration, override boundary, and inactive-vendored-theme contract were absent.
- An isolated exact-candidate build rendered all 46 articles and 2 pages, then the existing SITE-003 validator failed on its first legacy presentation assumption: the old `" - "` title separator instead of the candidate's `" — "` separator.

GREEN on the clean exact head:

- `./scripts/site test` — 19 passed.
- `uv run --locked --all-groups ruff check migration/site_build migration/site002v/validate.py migration/site003 migration/site006v plugins/site_metadata.py` — passed.
- `git diff --check`, clean-status gate, and credential-pattern scan — passed.
- `./scripts/site validate --work-root .../exact-head-site002v-validation --report-out .../exact-head-site002v-validation-report.json` — passed twice: 35 Markdown + 11 notebooks = 46 articles; all 7 isolated negative gates passed.
- Generated report matches `migration/site002v/evidence/validation.json` byte-for-byte.
- Deterministic route, metadata, asset, warning, publication, and theme-identity evidence matched across both clean locked builds.
- Lifecycle counts remain `9/13/16/8`; language counts remain `42 en / 4 ru`; archive/deprecation notices, no-execution, fatal-error, and completeness gates remain active.
- Installed package evidence records version `0.1.0`, PEP 610 repository URL, requested revision and commit `027a170ac6c8288347de5353569a089c526afae2`, and module/theme paths under external `site-packages`.
- Generated HTML has only same-origin candidate runtime assets (`theme/css/scaffold.css`, `theme/js/theme.js`), no active Bootstrap, jQuery, Font Awesome, Disqus, or legacy-theme assets.

Browser matrix on the clean exact head:

- Chromium `149.0.7827.55`, Playwright `1.61.0`, axe-core `4.12.1`.
- 390 x 844 and 1440 x 1000 across index, archive, article, notebook, page, plus a separate real wide-table notebook route.
- 12 light/dark/persistence/keyboard cases, 12 no-JavaScript cases, 24 axe scans, 3 print cases, 39 technical screenshots, zero external requests.
- The wide-table route has 4 local table scrollers at 390 px in light/dark mode with no page-level overflow; no-JavaScript fallback and print are separately gated.
- Exact content-owned axe ledger (any additional or changed finding fails): About source heading-order = 1 in four light/dark viewport scans; Number Sequences mobile color-contrast incomplete = 3 in light and dark; wide-table light color-contrast incomplete = 6 desktop / 99 mobile. These are historical content findings, not theme/runtime regressions.
- Four historical content-authored external image URLs are recorded separately by the full-output validator; selected browser routes made zero external requests. No external script, stylesheet, or iframe is active.
- Screenshots are technical evidence, not human acceptance.

## Changed areas

- Dependency and active theme configuration: `pyproject.toml`, `uv.lock`, `pelicanconf.py`, Markdown build config.
- Site-owned public overrides and lifecycle metadata: `templates/`, `plugins/site_metadata.py`.
- Cumulative SITE-002V/SITE-003/SITE-006V validators, tests, evidence, docs, and workflow.

No content files or vendored theme files changed.

## Rollback

Revert this one commit/PR. The previously vendored `theme/` directory remains intact for the pre-integration configuration path. `gh-pages` was not changed.

## Exclusions

No SITE-004 or SITE-005 content work. No merge, tag, GitHub Release, TestPyPI/PyPI publication, theme/package publication, Pages/DNS change, production deploy, `gh-pages` change, email, issue/comment/discussion, reviewer request, or maintainer/organization outreach.
