### PR TITLE
[CUT-001] Add production-equivalent preview evidence

### DIFF
--- a/.github/workflows/ops001.yml
+++ b/.github/workflows/ops001.yml
@@ -73,11 +73,54 @@ jobs:
             --accepted-migration-contracts \
             --report-out "$RUNNER_TEMP/ops001-validation.json"
 
+      - name: Materialize the exact CUT-001 production reference
+        run: |
+          production_commit='5c24ba21ec8b442e4b5280a47c85fab61165f8ce'
+          git fetch --no-tags origin gh-pages
+          test "$(git rev-parse FETCH_HEAD)" = "$production_commit"
+          git worktree add --detach \
+            "$RUNNER_TEMP/cut001-production" "$production_commit"
+          test "$(git -C "$RUNNER_TEMP/cut001-production" rev-parse HEAD)" = \
+            "$production_commit"
+
+      - name: Run the CUT-001 machine comparison
+        run: |
+          uv run --locked --all-groups python migration/cut001/validate.py \
+            --output-root "$RUNNER_TEMP/ops001-site" \
+            --production-root "$RUNNER_TEMP/cut001-production" \
+            --cumulative-report "$RUNNER_TEMP/cumulative-validation.json" \
+            --evidence-root "$RUNNER_TEMP/cut001-evidence"
+
+      - name: Install the exact CUT-001 browser runtime
+        run: |
+          theme_commit='027a170ac6c8288347de5353569a089c526afae2'
+          theme_dir="$RUNNER_TEMP/cut001-theme"
+          git clone --filter=blob:none --no-checkout \
+            https://github.com/nekrasovp/pelican-engineering-theme.git \
+            "$theme_dir"
+          git -C "$theme_dir" fetch --no-tags origin "$theme_commit"
+          git -C "$theme_dir" checkout --detach FETCH_HEAD
+          test "$(git -C "$theme_dir" rev-parse HEAD)" = "$theme_commit"
+          uv sync --project "$theme_dir" --locked --all-groups
+          npm ci --prefix "$theme_dir" --ignore-scripts
+          "$theme_dir/.venv/bin/python" -m playwright install --with-deps chromium
+
+      - name: Run the CUT-001 browser accessibility and visual matrix
+        run: |
+          theme_dir="$RUNNER_TEMP/cut001-theme"
+          "$theme_dir/.venv/bin/python" migration/cut001/browser_validate.py \
+            --output-root "$RUNNER_TEMP/ops001-site" \
+            --production-root "$RUNNER_TEMP/cut001-production" \
+            --artifact-root "$RUNNER_TEMP/cut001-evidence" \
+            --axe-script "$theme_dir/node_modules/axe-core/axe.min.js" \
+            --comparison-report "$RUNNER_TEMP/cut001-evidence/comparison.json"
+
       - name: Run regressions, scoped lint, and repository hygiene
         run: |
           ./scripts/site test
           uv run --locked --all-groups ruff check \
-            migration/site_build migration/ops001 migration/site002v/validate.py \
+            migration/site_build migration/ops001 migration/cut001 \
+            migration/site002v/validate.py \
             migration/site003 migration/site004 migration/site005 migration/site006v \
             plugins/site005_materials.py plugins/site_metadata.py
           git diff --check
@@ -108,6 +151,15 @@ jobs:
         with:
           name: ops001-review-${{ env.EXPECTED_HEAD }}
           path: ${{ runner.temp }}/ops001-site
+          if-no-files-found: error
+          include-hidden-files: true
+          retention-days: 14
+
+      - name: Upload the CUT-001 evidence package
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: cut001-evidence-${{ env.EXPECTED_HEAD }}
+          path: ${{ runner.temp }}/cut001-evidence
           if-no-files-found: error
           include-hidden-files: true
           retention-days: 14

--- a/migration/cut001/OWNER_VISUAL_REVIEW.md
+++ b/migration/cut001/OWNER_VISUAL_REVIEW.md
@@ -1,0 +1,71 @@
+# CUT-001 owner visual review guide
+
+This guide is the separate human visual-acceptance gate. The automated package
+proves deterministic captures, layout contracts, accessibility scans, route and
+content parity, and theme behavior. It does not make the owner's aesthetic or
+product decision.
+
+Use the `cut001-evidence-<exact-head>` artifact. For every canonical case below,
+compare the three screenshots at both `1440x1000` desktop and `390x844` mobile:
+legacy production reference, preview light, and preview dark.
+
+| Case | Route | Language / page type |
+| --- | --- | --- |
+| `home_en` | `/` | English home |
+| `home_ru` | `/ru/` | Russian home |
+| `work` | `/work/` | English work |
+| `about` | `/about/` | English about |
+| `writing` | `/writing/` | English writing/archive |
+| `modern_essay` | `/ai-native-sdlc-engineering-accountability.html` | modern English essay |
+| `legacy_markdown_en` | `/python-gil.html` | legacy English Markdown |
+| `legacy_markdown_ru` | `/technical-debt-examples.html` | legacy Russian Markdown |
+| `notebook_en` | `/number-sequences.html` | English notebook |
+| `notebook_ru` | `/mkrf-spb-geo-data.html` | Russian notebook and archived case |
+| `archive_en` | `/arbitrage.html` | archived English content |
+| `deprecated_en` | `/fixing-caching-sha2-password.html` | deprecated English content |
+| `not_found_en` | `/404.html` | static 404 |
+
+Two required matrix entries are canonical-equivalent rather than fabricated
+duplicate captures:
+
+- `archive_deprecated_ru` references `notebook_ru`; the Russian notebook is also
+  the Russian archived-notebook case.
+- `404_ru_acceptable` references `not_found_en`; the retained static 404 is the
+  language-neutral acceptable Russian case.
+
+Review:
+
+1. hierarchy, typography, spacing, navigation, code/notebook overflow, images,
+   archive/deprecation callouts, focus visibility, and light/dark contrast;
+2. English and Russian labels and reading order;
+3. desktop and mobile layout for every row;
+4. the theme toggle and persistence on representative normal, notebook, and 404
+   pages;
+5. every difference from legacy production as an intentional preview change,
+   not an accidental omission.
+
+The agent-managed browser spot check used the immutable artifact with a
+read-only local-origin rewrite solely so canonical absolute assets resolved from
+the artifact. It confirmed:
+
+- English home: expected heading; exactly one visible toggle; light to dark;
+- Russian home: `lang=ru`, expected heading, visible persisted dark toggle;
+- English notebook: expected title, one notebook region, 23 rendered images,
+  visible persisted dark toggle;
+- 404: expected heading, homepage/writing recovery links, visible toggle;
+- current live production home: expected legacy semantic content for comparison.
+
+The automated exact-origin harness, not that local rewrite, is authoritative for
+network isolation, 78 screenshots, 52 axe scans, and the 147-page toggle sweep.
+
+Record exactly one owner decision:
+
+- **Accept CUT-001 visual evidence** — visual gate passes; this does not make the
+  PR ready or authorize merge/deployment.
+- **Accept with named differences** — list every accepted difference by
+  case, viewport, and theme.
+- **Request rework** — list each rejected case, viewport, theme, and expected
+  correction.
+
+After visual acceptance, `ready`, `merge`, outreach, and CUT-002 remain separate
+owner-authorized gates. None is implied by this review.

--- a/migration/cut001/README.md
+++ b/migration/cut001/README.md
@@ -1,0 +1,75 @@
+# CUT-001 production-equivalent preview evidence
+
+CUT-001 builds the site from the exact accepted base
+`306028c8ab31a21a1297746b4176916315ba6a23` without changing any build input.
+It compares that immutable output with the exact legacy production tree
+`gh-pages@5c24ba21ec8b442e4b5280a47c85fab61165f8ce`.
+
+Locked identities:
+
+- site base tree: `0cc99d983dc302d08c7330b0451a82d61aa72541`
+- theme: `pelican-engineering-theme@027a170ac6c8288347de5353569a089c526afae2`
+- notebook reader: `pelican-jupyter@137e1eb0ea620f1b15fff0ba81725eea23de1b7a`
+
+The raw preview directory SHA-256 is an immutable identifier for one exact
+build and is recorded in its OPS/comparison report. It is not a cross-build
+constant: the retained `stock-market-portfolio-optimisation` notebook emits a
+random `output_widget_view` UUID into its HTML and two feeds. Cross-build
+reproducibility is therefore established by the cumulative validator's
+normalized publication, route, dependency, and theme gates.
+
+The cumulative validator remains the build and migration source of truth.
+`validate.py` composes its report with the OPS-001 validator, exact production
+tree, route/feed/sitemap/reference comparisons, parser checks, structured data,
+all notebook outputs, and theme-toggle markup. `browser_validate.py` then adds
+the complete screenshot matrix, axe results, runtime network observations, and
+the 147-page theme-toggle sweep.
+
+## Reproduce
+
+From a clean checkout of the CUT-001 head:
+
+```sh
+uv sync --locked --all-groups
+./scripts/site validate \
+  --work-root /tmp/site002v-cut001 \
+  --report-out /tmp/site002v-cut001/cumulative.json
+./scripts/site build --output /tmp/cut001-site
+
+git fetch --no-tags origin gh-pages
+test "$(git rev-parse FETCH_HEAD)" = \
+  5c24ba21ec8b442e4b5280a47c85fab61165f8ce
+git worktree add --detach /tmp/cut001-production \
+  5c24ba21ec8b442e4b5280a47c85fab61165f8ce
+
+uv run --locked --all-groups python migration/cut001/validate.py \
+  --output-root /tmp/cut001-site \
+  --production-root /tmp/cut001-production \
+  --cumulative-report /tmp/site002v-cut001/cumulative.json \
+  --evidence-root /tmp/cut001-evidence
+```
+
+Run the browser command from the exact locked development environment of the
+theme commit recorded above:
+
+```sh
+THEME_RUNTIME=/absolute/path/to/pelican-engineering-theme
+"$THEME_RUNTIME/.venv/bin/python" migration/cut001/browser_validate.py \
+  --output-root /tmp/cut001-site \
+  --production-root /tmp/cut001-production \
+  --artifact-root /tmp/cut001-evidence \
+  --axe-script "$THEME_RUNTIME/node_modules/axe-core/axe.min.js" \
+  --comparison-report /tmp/cut001-evidence/comparison.json
+```
+
+The final `manifest.json` covers all machine reports, browser reports, and
+screenshots. CI publishes two exact-head artifacts:
+`ops001-review-<head>` and `cut001-evidence-<head>`.
+
+## Boundaries and rollback
+
+This evidence is technical preparation, not owner visual acceptance, PR
+readiness, merge authority, deployment authority, or CUT-002 approval.
+Production remains unchanged. The rollback identifier is
+`gh-pages@5c24ba21ec8b442e4b5280a47c85fab61165f8ce`; discard the preview and
+re-materialize that exact tree if the preview is rejected.

--- a/migration/cut001/__init__.py
+++ b/migration/cut001/__init__.py
@@ -1,0 +1,1 @@
+"""CUT-001 production-equivalent preview validation."""

--- a/migration/cut001/browser_validate.py
+++ b/migration/cut001/browser_validate.py
@@ -1,0 +1,775 @@
+#!/usr/bin/env python3
+"""Run the CUT-001 browser, accessibility, and visual comparison matrix."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import mimetypes
+import re
+import subprocess
+import sys
+from importlib.metadata import version
+from pathlib import Path, PurePosixPath
+from typing import Any, Sequence
+from urllib.parse import quote, unquote, urlparse
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+from migration.cut001.evidence import build_evidence_manifest  # noqa: E402
+
+THEME_COMMIT = "027a170ac6c8288347de5353569a089c526afae2"
+READER_COMMIT = "137e1eb0ea620f1b15fff0ba81725eea23de1b7a"
+THEMELESS_REDIRECTS = {"pages/about.html", "pages/services.html"}
+VIEWPORTS = {
+    "desktop": {"width": 1440, "height": 1000},
+    "mobile": {"width": 390, "height": 844},
+}
+VISUAL_CASES: dict[str, dict[str, str]] = {
+    "home_en": {"language": "en", "page_type": "home", "route": "index.html"},
+    "home_ru": {"language": "ru", "page_type": "home", "route": "ru/index.html"},
+    "work": {
+        "language": "en",
+        "page_type": "work_about_writing",
+        "route": "work/index.html",
+    },
+    "about": {
+        "language": "en",
+        "page_type": "work_about_writing",
+        "route": "about/index.html",
+    },
+    "writing": {
+        "language": "en",
+        "page_type": "work_about_writing",
+        "route": "writing/index.html",
+    },
+    "modern_essay": {
+        "language": "en",
+        "page_type": "modern_essay",
+        "route": "ai-native-sdlc-engineering-accountability.html",
+    },
+    "legacy_markdown_en": {
+        "language": "en",
+        "page_type": "legacy_markdown",
+        "route": "python-gil.html",
+    },
+    "legacy_markdown_ru": {
+        "language": "ru",
+        "page_type": "legacy_markdown",
+        "route": "technical-debt-examples.html",
+    },
+    "notebook_en": {
+        "language": "en",
+        "page_type": "notebook",
+        "route": "number-sequences.html",
+    },
+    "notebook_ru": {
+        "language": "ru",
+        "page_type": "notebook",
+        "route": "mkrf-spb-geo-data.html",
+    },
+    "archive_en": {
+        "language": "en",
+        "page_type": "archive_deprecated",
+        "route": "arbitrage.html",
+    },
+    "deprecated_en": {
+        "language": "en",
+        "page_type": "archive_deprecated",
+        "route": "fixing-caching-sha2-password.html",
+    },
+    "not_found_en": {
+        "language": "en",
+        "page_type": "404",
+        "route": "404.html",
+    },
+}
+VISUAL_EQUIVALENCES = [
+    {
+        "canonical_case": "notebook_ru",
+        "reason": (
+            "The Russian notebook is also the only Russian archived notebook "
+            "case; duplicate pixels are referenced instead of fabricated."
+        ),
+        "virtual_case": "archive_deprecated_ru",
+    },
+    {
+        "canonical_case": "not_found_en",
+        "reason": (
+            "The static 404 document is language-neutral enough for the "
+            "plan's Russian acceptable case; duplicate pixels are referenced."
+        ),
+        "virtual_case": "404_ru_acceptable",
+    },
+]
+
+
+class BrowserValidationError(RuntimeError):
+    """A fail-closed browser or visual evidence violation."""
+
+
+def visual_matrix_contract() -> dict[str, Any]:
+    page_types: dict[str, set[str]] = {}
+    for case in VISUAL_CASES.values():
+        page_types.setdefault(case["page_type"], set()).add(case["language"])
+    page_types["archive_deprecated"].add("ru-equivalent")
+    page_types["404"].add("ru-equivalent")
+    return {
+        "page_types": page_types,
+        "themes": sorted(("light", "dark")),
+        "viewports": sorted(VIEWPORTS),
+    }
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _git(*arguments: str) -> str:
+    result = subprocess.run(
+        ["git", *arguments],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode:
+        raise BrowserValidationError(result.stderr.strip())
+    return result.stdout.strip()
+
+
+def _write_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _safe_output_file(output_root: Path, url_path: str) -> Path | None:
+    decoded = unquote(url_path)
+    relative = PurePosixPath(decoded.lstrip("/") or "index.html")
+    if relative.is_absolute() or ".." in relative.parts:
+        return None
+    if decoded.endswith("/"):
+        relative = relative / "index.html"
+    candidate = output_root.joinpath(*relative.parts)
+    return candidate if candidate.is_file() else None
+
+
+def _install_routes(
+    context: Any,
+    output_root: Path,
+    network: dict[str, list[dict[str, str]]],
+    *,
+    local_hosts: set[str],
+) -> None:
+    def handle(route: Any) -> None:
+        request = route.request
+        parsed = urlparse(request.url)
+        if parsed.hostname not in local_hosts:
+            network["blocked_external"].append(
+                {"resource_type": request.resource_type, "url": request.url}
+            )
+            route.abort()
+            return
+        candidate = _safe_output_file(output_root, parsed.path)
+        if candidate is None:
+            network["missing_same_origin"].append(
+                {"resource_type": request.resource_type, "url": request.url}
+            )
+            route.abort()
+            return
+        content_type = mimetypes.guess_type(candidate.name)[0] or "application/octet-stream"
+        network["fulfilled_same_origin"].append(
+            {"resource_type": request.resource_type, "url": request.url}
+        )
+        route.fulfill(
+            status=200,
+            body=candidate.read_bytes(),
+            content_type=content_type,
+        )
+
+    context.route("**/*", handle)
+
+
+def _network() -> dict[str, list[dict[str, str]]]:
+    return {
+        "blocked_external": [],
+        "fulfilled_same_origin": [],
+        "missing_same_origin": [],
+    }
+
+
+def _assert_network(
+    network: dict[str, list[dict[str, str]]],
+    *,
+    allowed_external_urls: set[str],
+    allowed_missing_same_origin_urls: set[str],
+    label: str,
+) -> None:
+    unexpected_missing = [
+        item
+        for item in network["missing_same_origin"]
+        if item["url"] not in allowed_missing_same_origin_urls
+    ]
+    if unexpected_missing:
+        raise BrowserValidationError(
+            f"{label} requested missing same-origin files: "
+            f"{unexpected_missing!r}"
+        )
+    unexpected = sorted(
+        {
+            item["url"]
+            for item in network["blocked_external"]
+            if item["url"] not in allowed_external_urls
+        }
+    )
+    if unexpected:
+        raise BrowserValidationError(
+            f"{label} requested unreviewed external resources: {unexpected!r}"
+        )
+
+
+def _assert_exact_observations(
+    *, expected: set[str], observed: set[str], label: str
+) -> None:
+    missing = sorted(expected - observed)
+    unexpected = sorted(observed - expected)
+    if missing or unexpected:
+        raise BrowserValidationError(
+            f"{label} observation drift: missing={missing!r}, "
+            f"unexpected={unexpected!r}"
+        )
+
+
+def _layout(page: Any, *, expected_language: str) -> dict[str, Any]:
+    observation = page.evaluate(
+        """expectedLanguage => {
+          const toggle = document.querySelector('[data-pet-theme-toggle]');
+          return {
+            ariaPressed: toggle?.getAttribute('aria-pressed') || null,
+            documentWidth: document.documentElement.scrollWidth,
+            language: document.documentElement.lang,
+            mainCount: document.querySelectorAll('main#main-content').length,
+            theme: document.documentElement.dataset.theme || 'light',
+            toggleCount: document.querySelectorAll('[data-pet-theme-toggle]').length,
+            toggleHidden: toggle?.hidden ?? null,
+            viewportWidth: window.innerWidth,
+            expectedLanguage
+          };
+        }""",
+        expected_language,
+    )
+    if (
+        observation["language"] != expected_language
+        or observation["mainCount"] != 1
+        or observation["toggleCount"] != 1
+        or observation["toggleHidden"] is not False
+        or observation["documentWidth"] > observation["viewportWidth"] + 1
+    ):
+        raise BrowserValidationError(f"visual layout contract failed: {observation!r}")
+    return observation
+
+
+def _axe(page: Any, axe_script: Path) -> dict[str, Any]:
+    page.add_script_tag(path=str(axe_script))
+    result = page.evaluate(
+        """async () => {
+          const report = await axe.run(document, {
+            resultTypes: ['violations', 'incomplete']
+          });
+          const slim = item => ({
+            id: item.id,
+            impact: item.impact,
+            nodes: item.nodes.length
+          });
+          return {
+            incomplete: report.incomplete.map(slim),
+            passes: report.passes.length,
+            violations: report.violations.map(slim)
+          };
+        }"""
+    )
+    if result["violations"]:
+        raise BrowserValidationError(f"axe violations found: {result['violations']!r}")
+    return result
+
+
+def _screenshot(page: Any, artifact_root: Path, name: str) -> dict[str, Any]:
+    path = artifact_root / "screenshots" / f"{name}.png"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    page.screenshot(path=str(path), full_page=False)
+    return {
+        "path": path.relative_to(artifact_root).as_posix(),
+        "sha256": _sha256(path),
+        "size": path.stat().st_size,
+    }
+
+
+def _preview_case(
+    browser: Any,
+    *,
+    artifact_root: Path,
+    axe_script: Path,
+    case_name: str,
+    case: dict[str, str],
+    output_root: Path,
+    viewport_name: str,
+    viewport: dict[str, int],
+    allowed_external_urls: set[str],
+    allowed_missing_same_origin_urls: set[str],
+) -> dict[str, Any]:
+    network = _network()
+    context = browser.new_context(viewport=viewport)
+    _install_routes(
+        context,
+        output_root,
+        network,
+        local_hosts={"nekrasovp.ru"},
+    )
+    page = context.new_page()
+    page.goto(
+        f"https://nekrasovp.ru/{case['route']}",
+        wait_until="networkidle",
+    )
+    light = _layout(page, expected_language=case["language"])
+    if light["theme"] != "light" or light["ariaPressed"] != "false":
+        raise BrowserValidationError(
+            f"{case_name}:{viewport_name} did not start light: {light!r}"
+        )
+    axe_light = _axe(page, axe_script)
+    light_screenshot = _screenshot(
+        page,
+        artifact_root,
+        f"{case_name}-{viewport_name}-preview-light",
+    )
+    page.locator("[data-pet-theme-toggle]").click()
+    dark = page.evaluate(
+        """() => {
+          const toggle = document.querySelector('[data-pet-theme-toggle]');
+          return {
+            ariaPressed: toggle?.getAttribute('aria-pressed') || null,
+            stored: localStorage.getItem('pelican-engineering-theme'),
+            theme: document.documentElement.dataset.theme || 'light'
+          };
+        }"""
+    )
+    if dark != {"ariaPressed": "true", "stored": "dark", "theme": "dark"}:
+        raise BrowserValidationError(
+            f"{case_name}:{viewport_name} dark toggle failed: {dark!r}"
+        )
+    axe_dark = _axe(page, axe_script)
+    dark_screenshot = _screenshot(
+        page,
+        artifact_root,
+        f"{case_name}-{viewport_name}-preview-dark",
+    )
+    context.close()
+    _assert_network(
+        network,
+        allowed_external_urls=allowed_external_urls,
+        allowed_missing_same_origin_urls=allowed_missing_same_origin_urls,
+        label=f"{case_name}:{viewport_name}:preview",
+    )
+    return {
+        "accessibility": {"dark": axe_dark, "light": axe_light},
+        "dark": dark,
+        "language": case["language"],
+        "light": light,
+        "network": {
+            "blocked_external": network["blocked_external"],
+            "fulfilled_same_origin": len(network["fulfilled_same_origin"]),
+            "missing_same_origin": network["missing_same_origin"],
+            "outbound_requests": 0,
+        },
+        "page_type": case["page_type"],
+        "route": case["route"],
+        "screenshots": {"dark": dark_screenshot, "light": light_screenshot},
+        "viewport": viewport,
+    }
+
+
+def _production_reference(
+    browser: Any,
+    *,
+    artifact_root: Path,
+    case_name: str,
+    case: dict[str, str],
+    production_root: Path,
+    viewport_name: str,
+    viewport: dict[str, int],
+    allowed_external_urls: set[str],
+    allowed_missing_same_origin_urls: set[str],
+) -> dict[str, Any]:
+    network = _network()
+    context = browser.new_context(viewport=viewport)
+    _install_routes(
+        context,
+        production_root,
+        network,
+        local_hosts={"nekrasovp.github.io", "nekrasovp.ru"},
+    )
+    page = context.new_page()
+    page.goto(
+        f"https://nekrasovp.ru/{case['route']}",
+        wait_until="networkidle",
+    )
+    observation = page.evaluate(
+        """() => ({
+          documentWidth: document.documentElement.scrollWidth,
+          language: document.documentElement.lang || null,
+          viewportWidth: window.innerWidth
+        })"""
+    )
+    screenshot = _screenshot(
+        page,
+        artifact_root,
+        f"{case_name}-{viewport_name}-production",
+    )
+    context.close()
+    _assert_network(
+        network,
+        allowed_external_urls=allowed_external_urls,
+        allowed_missing_same_origin_urls=allowed_missing_same_origin_urls,
+        label=f"{case_name}:{viewport_name}:production",
+    )
+    return {
+        "network": {
+            "blocked_external": network["blocked_external"],
+            "fulfilled_same_origin": len(network["fulfilled_same_origin"]),
+            "missing_same_origin": network["missing_same_origin"],
+            "outbound_requests": 0,
+        },
+        "observation": observation,
+        "screenshot": screenshot,
+        "viewport": viewport,
+    }
+
+
+def _all_page_toggle(
+    browser: Any,
+    *,
+    output_root: Path,
+    allowed_external_urls: set[str],
+    allowed_missing_same_origin_urls: set[str],
+) -> dict[str, Any]:
+    network = _network()
+    context = browser.new_context(viewport=VIEWPORTS["desktop"])
+    _install_routes(
+        context,
+        output_root,
+        network,
+        local_hosts={"nekrasovp.ru"},
+    )
+    page = context.new_page()
+    records: list[dict[str, Any]] = []
+    for path in sorted(output_root.rglob("*.html")):
+        relative = path.relative_to(output_root).as_posix()
+        if relative in THEMELESS_REDIRECTS:
+            continue
+        page.goto(f"https://nekrasovp.ru/{relative}", wait_until="domcontentloaded")
+        page.evaluate("localStorage.removeItem('pelican-engineering-theme')")
+        page.reload(wait_until="domcontentloaded")
+        before = page.evaluate(
+            """() => {
+              const toggle = document.querySelector('[data-pet-theme-toggle]');
+              return {
+                ariaPressed: toggle?.getAttribute('aria-pressed') || null,
+                theme: document.documentElement.dataset.theme || 'light',
+                toggleCount: document.querySelectorAll(
+                  '[data-pet-theme-toggle]'
+                ).length,
+                toggleHidden: toggle?.hidden ?? null
+              };
+            }"""
+        )
+        if before != {
+            "ariaPressed": "false",
+            "theme": "light",
+            "toggleCount": 1,
+            "toggleHidden": False,
+        }:
+            raise BrowserValidationError(
+                f"all-page first-visit toggle failed for {relative}: {before!r}"
+            )
+        page.locator("[data-pet-theme-toggle]").click()
+        after = page.evaluate(
+            """() => ({
+              ariaPressed: document.querySelector(
+                '[data-pet-theme-toggle]'
+              )?.getAttribute('aria-pressed') || null,
+              stored: localStorage.getItem('pelican-engineering-theme'),
+              theme: document.documentElement.dataset.theme || 'light'
+            })"""
+        )
+        if after != {"ariaPressed": "true", "stored": "dark", "theme": "dark"}:
+            raise BrowserValidationError(
+                f"all-page dark toggle failed for {relative}: {after!r}"
+            )
+        records.append({"after": after, "before": before, "output": relative})
+    context.close()
+    _assert_network(
+        network,
+        allowed_external_urls=allowed_external_urls,
+        allowed_missing_same_origin_urls=allowed_missing_same_origin_urls,
+        label="all-page-toggle",
+    )
+    if len(records) != 147:
+        raise BrowserValidationError(
+            f"expected 147 themed pages in the runtime toggle gate, got {len(records)}"
+        )
+    return {
+        "blocked_external": network["blocked_external"],
+        "count": len(records),
+        "missing_same_origin": network["missing_same_origin"],
+        "outbound_requests": 0,
+        "records": records,
+        "standalone_redirect_exemptions": sorted(THEMELESS_REDIRECTS),
+    }
+
+
+def run(args: argparse.Namespace) -> dict[str, Any]:
+    try:
+        from playwright.sync_api import sync_playwright
+    except ImportError as error:
+        raise BrowserValidationError(
+            "use the exact locked theme development environment"
+        ) from error
+
+    output_root = args.output_root.resolve()
+    production_root = args.production_root.resolve()
+    artifact_root = args.artifact_root.resolve()
+    axe_script = args.axe_script.resolve()
+    comparison = json.loads(args.comparison_report.read_text(encoding="utf-8"))
+    allowed_external_urls = {
+        record["url"]
+        for field in (
+            "external_preview_assets",
+            "external_production_assets",
+            "intentional_production_runtime_external",
+        )
+        for record in comparison["references"][field]
+    }
+    expected_runtime_external = {
+        record["url"]
+        for record in comparison["references"][
+            "intentional_production_runtime_external"
+        ]
+    }
+    allowed_missing_same_origin_urls = {
+        "https://nekrasovp.ru/"
+        + quote(record["target"], safe="/")
+        for record in comparison["references"]["assets"]["unchanged_records"]
+    }
+    if (
+        not output_root.is_dir()
+        or not production_root.is_dir()
+        or not axe_script.is_file()
+    ):
+        raise BrowserValidationError(
+            "preview, production, or exact axe-core source is unavailable"
+        )
+    artifact_root.mkdir(parents=True, exist_ok=True)
+    for case in VISUAL_CASES.values():
+        if not (output_root / case["route"]).is_file():
+            raise BrowserValidationError(
+                f"preview matrix route is missing: {case['route']}"
+            )
+        if not (production_root / case["route"]).is_file():
+            raise BrowserValidationError(
+                f"production matrix route is missing: {case['route']}"
+            )
+
+    preview_cases: dict[str, Any] = {}
+    production_cases: dict[str, Any] = {}
+    with sync_playwright() as playwright:
+        browser = playwright.chromium.launch()
+        browser_version = browser.version
+        for case_name, case in VISUAL_CASES.items():
+            for viewport_name, viewport in VIEWPORTS.items():
+                key = f"{case_name}:{viewport_name}"
+                preview_cases[key] = _preview_case(
+                    browser,
+                    artifact_root=artifact_root,
+                    axe_script=axe_script,
+                    case_name=case_name,
+                    case=case,
+                    output_root=output_root,
+                    viewport_name=viewport_name,
+                    viewport=viewport,
+                    allowed_external_urls=allowed_external_urls,
+                    allowed_missing_same_origin_urls=(
+                        allowed_missing_same_origin_urls
+                    ),
+                )
+                production_cases[key] = _production_reference(
+                    browser,
+                    artifact_root=artifact_root,
+                    case_name=case_name,
+                    case=case,
+                    production_root=production_root,
+                    viewport_name=viewport_name,
+                    viewport=viewport,
+                    allowed_external_urls=allowed_external_urls,
+                    allowed_missing_same_origin_urls=(
+                        allowed_missing_same_origin_urls
+                    ),
+                )
+        all_page_toggle = _all_page_toggle(
+            browser,
+            output_root=output_root,
+            allowed_external_urls=allowed_external_urls,
+            allowed_missing_same_origin_urls=allowed_missing_same_origin_urls,
+        )
+        browser.close()
+
+    accessibility_cases = {
+        key: value["accessibility"] for key, value in preview_cases.items()
+    }
+    incomplete = sum(
+        len(theme["incomplete"])
+        for case in accessibility_cases.values()
+        for theme in case.values()
+    )
+    screenshot_matrix = {
+        key: {
+            "dark": value["screenshots"]["dark"],
+            "light": value["screenshots"]["light"],
+            "production": production_cases[key]["screenshot"],
+        }
+        for key, value in preview_cases.items()
+    }
+    for equivalence in VISUAL_EQUIVALENCES:
+        canonical = equivalence["canonical_case"]
+        screenshot_matrix[equivalence["virtual_case"]] = {
+            "canonical_case": canonical,
+            "reason": equivalence["reason"],
+            "screenshots": {
+                viewport: screenshot_matrix[f"{canonical}:{viewport}"]
+                for viewport in VIEWPORTS
+            },
+            "visual_equivalence": True,
+        }
+    observed_runtime_external = {
+        item["url"]
+        for case in production_cases.values()
+        for item in case["network"]["blocked_external"]
+    }
+    _assert_exact_observations(
+        expected=expected_runtime_external,
+        observed=observed_runtime_external & expected_runtime_external,
+        label="production runtime external allowlist",
+    )
+    observed_missing_same_origin = {
+        item["url"]
+        for case in (*preview_cases.values(), *production_cases.values())
+        for item in case["network"]["missing_same_origin"]
+    } | {
+        item["url"] for item in all_page_toggle["missing_same_origin"]
+    }
+    _assert_exact_observations(
+        expected=allowed_missing_same_origin_urls,
+        observed=observed_missing_same_origin,
+        label="unchanged missing same-origin asset allowlist",
+    )
+
+    accessibility = {
+        "axe_core": re.search(
+            r"axe v([0-9.]+)",
+            axe_script.read_text(encoding="utf-8", errors="ignore"),
+        )[1],
+        "cases": accessibility_cases,
+        "contract": "nekrasovp-cut001-accessibility.v1",
+        "incomplete_groups": incomplete,
+        "scans": len(accessibility_cases) * 2,
+        "violations": 0,
+    }
+    matrix = {
+        "cases": screenshot_matrix,
+        "contract": "nekrasovp-cut001-screenshot-matrix.v1",
+        "equivalences": VISUAL_EQUIVALENCES,
+        "owner_visual_acceptance": "not_performed",
+        "production_reference_commit": (
+            "5c24ba21ec8b442e4b5280a47c85fab61165f8ce"
+        ),
+        "technical_evidence_not_human_acceptance": True,
+        "visual_cases": VISUAL_CASES,
+    }
+    report = {
+        "accessibility": accessibility,
+        "all_generated_pages_theme_toggle": all_page_toggle,
+        "chromium": browser_version,
+        "contract": "nekrasovp-cut001-browser.v1",
+        "playwright": version("playwright"),
+        "preview_cases": preview_cases,
+        "production_cases": production_cases,
+        "production_runtime_external": {
+            "expected": sorted(expected_runtime_external),
+            "observed": sorted(observed_runtime_external),
+        },
+        "unchanged_missing_same_origin_assets": {
+            "expected": sorted(allowed_missing_same_origin_urls),
+            "observed": sorted(observed_missing_same_origin),
+        },
+        "reader_commit": READER_COMMIT,
+        "source_head": _git("rev-parse", "HEAD"),
+        "source_status": _git(
+            "status",
+            "--porcelain=v1",
+            "--untracked-files=all",
+        ),
+        "technical_evidence_not_human_acceptance": True,
+        "theme_commit": THEME_COMMIT,
+        "totals": {
+            "accessibility_scans": accessibility["scans"],
+            "all_page_toggle_cases": all_page_toggle["count"],
+            "external_outbound_requests": 0,
+            "production_reference_screenshots": len(production_cases),
+            "screenshots": len(list((artifact_root / "screenshots").glob("*.png"))),
+            "visual_preview_cases": len(preview_cases),
+        },
+        "visual_equivalences": VISUAL_EQUIVALENCES,
+    }
+    _write_json(artifact_root / "accessibility.json", accessibility)
+    _write_json(artifact_root / "screenshot-matrix.json", matrix)
+    _write_json(artifact_root / "browser-report.json", report)
+    _write_json(
+        artifact_root / "manifest.json",
+        build_evidence_manifest(artifact_root, report["source_head"]),
+    )
+    return report
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser(description=__doc__)
+    result.add_argument("--output-root", type=Path, required=True)
+    result.add_argument("--production-root", type=Path, required=True)
+    result.add_argument("--artifact-root", type=Path, required=True)
+    result.add_argument("--axe-script", type=Path, required=True)
+    result.add_argument("--comparison-report", type=Path, required=True)
+    return result
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    try:
+        report = run(parser().parse_args(argv))
+    except Exception as error:
+        print(f"CUT-001 browser validation failed: {error}", file=sys.stderr)
+        return 1
+    totals = report["totals"]
+    print(
+        "CUT-001 browser validation passed: "
+        f"{totals['visual_preview_cases']} preview cases, "
+        f"{totals['production_reference_screenshots']} production references, "
+        f"{totals['accessibility_scans']} axe scans, "
+        f"{totals['all_page_toggle_cases']} generated-page toggle cases, "
+        f"{totals['external_outbound_requests']} outbound requests"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/migration/cut001/evidence.py
+++ b/migration/cut001/evidence.py
@@ -1,0 +1,31 @@
+"""Standard-library-only CUT-001 evidence package manifest."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from typing import Any
+
+
+def build_evidence_manifest(
+    evidence_root: Path,
+    source_commit: str,
+) -> dict[str, Any]:
+    files = []
+    for path in sorted(
+        item
+        for item in evidence_root.rglob("*")
+        if item.is_file() and item.name != "manifest.json"
+    ):
+        files.append(
+            {
+                "path": path.relative_to(evidence_root).as_posix(),
+                "sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
+                "size": path.stat().st_size,
+            }
+        )
+    return {
+        "contract": "nekrasovp-cut001-evidence-manifest.v1",
+        "files": files,
+        "source_commit": source_commit,
+    }

--- a/migration/cut001/intentional_differences.json
+++ b/migration/cut001/intentional_differences.json
@@ -1,0 +1,22 @@
+{
+  "added_feeds": {
+    "/feeds/misc.atom.xml": "SITE-005 adds the deterministic three-entry materials feed."
+  },
+  "added_routes": {},
+  "canonical_or_hreflang": {
+    "count": 89,
+    "reason": "Accepted migration output adds deterministic canonicals to taxonomy/archive pages and correct pagination canonicals; the same production metadata delta is already fail-closed by the OPS-001 reviewed-difference fingerprint.",
+    "sha256": "c7a6f993d107161ea3162f4dfdfc79194aaaab534631aebbd976a72199638e23"
+  },
+  "contract": "nekrasovp-cut001-intentional-differences.v1",
+  "missing_routes": {},
+  "new_broken_assets": {},
+  "new_broken_links": {},
+  "production_commit": "5c24ba21ec8b442e4b5280a47c85fab61165f8ce",
+  "production_runtime_external": {
+    "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML": "Legacy production notebooks inject MathJax 2.7.1 from cdnjs; CUT-001 blocks it and the immutable reader preview has no equivalent external runtime dependency.",
+    "https://fonts.googleapis.com/css?family=Lato:400,700,400italic": "The legacy production theme requests its Lato stylesheet at runtime; CUT-001 blocks it and the preview has no equivalent external runtime dependency.",
+    "https://nekrasovp.disqus.com/count.js": "The legacy production theme injects the Disqus counter; CUT-001 blocks it and the preview has no equivalent external runtime dependency.",
+    "https://nekrasovp.disqus.com/embed.js": "The legacy production article template injects the Disqus embed; CUT-001 blocks it and the preview has no equivalent external runtime dependency."
+  }
+}

--- a/migration/cut001/validate.py
+++ b/migration/cut001/validate.py
@@ -1,0 +1,862 @@
+#!/usr/bin/env python3
+"""Compose cumulative and OPS-001 gates into the CUT-001 comparison package."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import posixpath
+import subprocess
+import sys
+import xml.etree.ElementTree as ET
+from collections import Counter
+from pathlib import Path, PurePosixPath
+from typing import Any, Iterable, Sequence
+from urllib.parse import unquote, urlsplit
+
+from bs4 import BeautifulSoup
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BASELINE_ROOT = REPO_ROOT / "migration/production_parity/baseline"
+BASELINE_SCRIPTS = REPO_ROOT / "migration/production_parity/scripts"
+INTENTIONAL_DIFFERENCES = REPO_ROOT / "migration/cut001/intentional_differences.json"
+NOTEBOOK_MANIFEST = REPO_ROOT / "migration/site002v/notebooks.tsv"
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(BASELINE_SCRIPTS))
+
+from baseline_common import (  # noqa: E402
+    load_json,
+    parse_atom,
+    sitemap_urls,
+    tree_file_to_route,
+)
+
+from migration.cut001.evidence import build_evidence_manifest  # noqa: E402
+from migration.ops001.validate import validate_artifact  # noqa: E402
+
+BASE_COMMIT = "306028c8ab31a21a1297746b4176916315ba6a23"
+BASE_TREE = "0cc99d983dc302d08c7330b0451a82d61aa72541"
+PRODUCTION_COMMIT = "5c24ba21ec8b442e4b5280a47c85fab61165f8ce"
+THEME_COMMIT = "027a170ac6c8288347de5353569a089c526afae2"
+READER_COMMIT = "137e1eb0ea620f1b15fff0ba81725eea23de1b7a"
+CANONICAL_HOST = "nekrasovp.ru"
+THEMELESS_REDIRECTS = {"pages/about.html", "pages/services.html"}
+BUILD_INPUT_PATHS = (
+    "content",
+    "pelicanconf.py",
+    "plugins",
+    "publishconf.py",
+    "templates",
+    "uv.lock",
+)
+HTML_ASSET_ATTRIBUTES = (
+    ("img", "src"),
+    ("script", "src"),
+    ("source", "src"),
+    ("video", "poster"),
+)
+
+
+class Cut001ValidationError(RuntimeError):
+    """A fail-closed CUT-001 contract violation."""
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _write_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _git(*arguments: str, cwd: Path = REPO_ROOT) -> str:
+    result = subprocess.run(
+        ["git", *arguments],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode:
+        raise Cut001ValidationError(result.stderr.strip() or result.stdout.strip())
+    return result.stdout.strip()
+
+
+def _html_routes(root: Path) -> dict[str, str]:
+    routes: dict[str, str] = {}
+    for path in sorted(root.rglob("*.html")):
+        relative = path.relative_to(root).as_posix()
+        route = tree_file_to_route(relative)
+        if route is None:
+            raise Cut001ValidationError(f"cannot derive route for {relative}")
+        routes[route] = relative
+    return routes
+
+
+def _check_exact_allowlist(
+    *,
+    observed: set[str],
+    allowlist: dict[str, str],
+    label: str,
+) -> None:
+    allowed = set(allowlist)
+    unexplained = sorted(observed - allowed)
+    stale = sorted(allowed - observed)
+    if unexplained:
+        raise Cut001ValidationError(f"unexplained {label}: {unexplained!r}")
+    if stale:
+        raise Cut001ValidationError(f"stale {label} allowlist: {stale!r}")
+
+
+def compare_routes(
+    preview_root: Path,
+    production_root: Path,
+    *,
+    intentional_added: dict[str, str],
+    intentional_missing: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    """Require exact route-set parity except for an exact reviewed allowlist."""
+
+    preview = _html_routes(preview_root.resolve())
+    production = _html_routes(production_root.resolve())
+    added = set(preview) - set(production)
+    missing = set(production) - set(preview)
+    missing_allowlist = intentional_missing or {}
+    _check_exact_allowlist(
+        observed=added,
+        allowlist=intentional_added,
+        label="added routes",
+    )
+    _check_exact_allowlist(
+        observed=missing,
+        allowlist=missing_allowlist,
+        label="missing routes",
+    )
+    return {
+        "added": [
+            {"reason": intentional_added[route], "route": route}
+            for route in sorted(added)
+        ],
+        "common": len(set(preview) & set(production)),
+        "missing": [
+            {"reason": missing_allowlist[route], "route": route}
+            for route in sorted(missing)
+        ],
+        "preview_count": len(preview),
+        "production_count": len(production),
+    }
+
+
+def _feed_paths(root: Path) -> dict[str, Path]:
+    feed_root = root / "feeds"
+    if not feed_root.is_dir():
+        return {}
+    return {
+        f"/feeds/{path.name}": path
+        for path in sorted(feed_root.glob("*.xml"))
+        if path.is_file()
+    }
+
+
+def compare_feeds(
+    preview_root: Path,
+    production_root: Path,
+    *,
+    intentional_added_feeds: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    """Prove historical IDs and stable entry routing across exact feed trees."""
+
+    preview_paths = _feed_paths(preview_root.resolve())
+    production_paths = _feed_paths(production_root.resolve())
+    added = set(preview_paths) - set(production_paths)
+    missing = set(production_paths) - set(preview_paths)
+    allowlist = intentional_added_feeds or {}
+    _check_exact_allowlist(
+        observed=added,
+        allowlist=allowlist,
+        label="added feeds",
+    )
+    if missing:
+        raise Cut001ValidationError(f"missing production feeds: {sorted(missing)!r}")
+
+    records: list[dict[str, Any]] = []
+    historical_total = 0
+    for feed_path in sorted(set(preview_paths) & set(production_paths)):
+        preview = parse_atom(preview_paths[feed_path].read_bytes())
+        production = parse_atom(production_paths[feed_path].read_bytes())
+        preview_by_id = {entry["id"]: entry for entry in preview["entries"]}
+        production_by_id = {entry["id"]: entry for entry in production["entries"]}
+        production_ids = set(production_by_id)
+        preview_ids = set(preview_by_id)
+        missing_ids = sorted(production_ids - preview_ids)
+        if missing_ids:
+            raise Cut001ValidationError(
+                f"historical feed IDs missing from {feed_path}: {missing_ids!r}"
+            )
+        historical_total += len(production_ids)
+        routing_differences: list[dict[str, Any]] = []
+        presentation_differences: list[dict[str, Any]] = []
+        for identifier in sorted(production_ids):
+            before = production_by_id[identifier]
+            after = preview_by_id[identifier]
+            for field in ("url", "published", "updated"):
+                if before.get(field) != after.get(field):
+                    routing_differences.append(
+                        {
+                            "after": after.get(field),
+                            "before": before.get(field),
+                            "field": field,
+                            "id": identifier,
+                        }
+                    )
+            for field in ("categories", "title"):
+                if before.get(field) != after.get(field):
+                    presentation_differences.append(
+                        {
+                            "after": after.get(field),
+                            "before": before.get(field),
+                            "field": field,
+                            "id": identifier,
+                        }
+                    )
+        if routing_differences:
+            raise Cut001ValidationError(
+                f"historical feed entry routing changed in {feed_path}: "
+                f"{routing_differences!r}"
+            )
+        records.append(
+            {
+                "added_ids": sorted(preview_ids - production_ids),
+                "feed": feed_path,
+                "historical_ids": len(production_ids),
+                "presentation_differences": presentation_differences,
+                "preview_entries": preview["entry_count"],
+                "production_entries": production["entry_count"],
+                "routing_differences": [],
+            }
+        )
+
+    return {
+        "added_feeds": [
+            {"feed": path, "reason": allowlist[path]} for path in sorted(added)
+        ],
+        "common_feeds": records,
+        "historical_id_occurrences_preserved": historical_total,
+        "missing_feeds": [],
+    }
+
+
+def _metadata(path: Path) -> dict[str, Any]:
+    soup = BeautifulSoup(path.read_bytes(), "html.parser")
+    canonical = None
+    hreflang: dict[str, str] = {}
+    for node in soup.find_all("link", href=True):
+        rel = node.get("rel") or []
+        tokens = {str(value).casefold() for value in rel}
+        if "canonical" in tokens:
+            canonical = str(node["href"])
+        if "alternate" in tokens and node.get("hreflang"):
+            hreflang[str(node["hreflang"])] = str(node["href"])
+    html = soup.find("html")
+    return {
+        "canonical": canonical,
+        "hreflang": dict(sorted(hreflang.items())),
+        "lang": html.get("lang") if html else None,
+    }
+
+
+def _canonical_equivalent(before: str | None, after: str | None) -> bool:
+    if before is None or after is None:
+        return before == after
+    return before.rstrip("/") == after.rstrip("/")
+
+
+def compare_canonical_hreflang(
+    preview_root: Path,
+    production_root: Path,
+    *,
+    intentional: dict[str, Any],
+) -> dict[str, Any]:
+    preview = _html_routes(preview_root)
+    production = _html_routes(production_root)
+    differences: list[dict[str, Any]] = []
+    equivalent: list[dict[str, Any]] = []
+    for route in sorted(set(preview) & set(production)):
+        before = _metadata(production_root / production[route])
+        after = _metadata(preview_root / preview[route])
+        changed = {
+            field: {"after": after[field], "before": before[field]}
+            for field in ("canonical", "hreflang", "lang")
+            if before[field] != after[field]
+        }
+        if not changed:
+            continue
+        only_equivalent_canonical = (
+            set(changed) == {"canonical"}
+            and _canonical_equivalent(before["canonical"], after["canonical"])
+        )
+        if only_equivalent_canonical:
+            equivalent.append({"changes": changed, "route": route})
+            continue
+        differences.append({"changes": changed, "route": route})
+    payload = (
+        json.dumps(
+            differences,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        + "\n"
+    ).encode()
+    fingerprint = hashlib.sha256(payload).hexdigest()
+    if (
+        len(differences) != intentional.get("count")
+        or fingerprint != intentional.get("sha256")
+    ):
+        raise Cut001ValidationError(
+            "unexplained canonical/hreflang difference fingerprint: "
+            f"expected_count={intentional.get('count')!r} "
+            f"actual_count={len(differences)} "
+            f"expected_sha256={intentional.get('sha256')!r} "
+            f"actual_sha256={fingerprint}"
+        )
+    reason = intentional.get("reason")
+    if not isinstance(reason, str) or not reason:
+        raise Cut001ValidationError("canonical/hreflang reason is missing")
+    return {
+        "canonical_equivalent": equivalent,
+        "compared_routes": len(set(preview) & set(production)),
+        "intentional_differences": [
+            {**record, "reason": reason} for record in differences
+        ],
+        "intentional_differences_fingerprint": {
+            "count": len(differences),
+            "sha256": fingerprint,
+        },
+    }
+
+
+def validate_structured_data(output_root: Path) -> dict[str, Any]:
+    documents = 0
+    files = 0
+    types: Counter[str] = Counter()
+    errors: list[str] = []
+
+    def collect_types(value: Any) -> None:
+        if isinstance(value, dict):
+            candidate = value.get("@type")
+            if isinstance(candidate, str):
+                types[candidate] += 1
+            elif isinstance(candidate, list):
+                types.update(item for item in candidate if isinstance(item, str))
+            for nested in value.values():
+                collect_types(nested)
+        elif isinstance(value, list):
+            for nested in value:
+                collect_types(nested)
+
+    for path in sorted(output_root.resolve().rglob("*.html")):
+        files += 1
+        relative = path.relative_to(output_root).as_posix()
+        soup = BeautifulSoup(path.read_bytes(), "html.parser")
+        for number, node in enumerate(
+            soup.find_all("script", attrs={"type": "application/ld+json"}),
+            start=1,
+        ):
+            documents += 1
+            try:
+                value = json.loads(node.string or node.get_text())
+            except (json.JSONDecodeError, TypeError) as error:
+                errors.append(f"{relative}#{number}: {error}")
+                continue
+            collect_types(value)
+    if errors:
+        raise Cut001ValidationError(f"invalid JSON-LD: {errors!r}")
+    return {
+        "documents": documents,
+        "files": files,
+        "types": dict(sorted(types.items())),
+    }
+
+
+def validate_theme_toggle_markup(output_root: Path) -> dict[str, Any]:
+    checked = 0
+    exempt: list[str] = []
+    errors: list[str] = []
+    for path in sorted(output_root.resolve().rglob("*.html")):
+        relative = path.relative_to(output_root).as_posix()
+        if relative in THEMELESS_REDIRECTS:
+            exempt.append(relative)
+            continue
+        soup = BeautifulSoup(path.read_bytes(), "html.parser")
+        toggles = soup.select("[data-pet-theme-toggle]")
+        scripts = {
+            str(node.get("src"))
+            for node in soup.find_all("script", src=True)
+        }
+        if (
+            len(toggles) != 1
+            or toggles[0].get("aria-pressed") != "false"
+            or not any(urlsplit(value).path == "/theme/js/theme.js" for value in scripts)
+        ):
+            errors.append(relative)
+        checked += 1
+    if errors:
+        raise Cut001ValidationError(
+            f"theme toggle contract failed for generated pages: {errors!r}"
+        )
+    return {"checked": checked, "exempt": exempt}
+
+
+def _reference_target(
+    *,
+    source: str,
+    url: str,
+) -> tuple[str, str] | None:
+    parsed = urlsplit(url)
+    if parsed.scheme in {"data", "javascript", "mailto", "tel"}:
+        return None
+    if parsed.hostname and parsed.hostname != CANONICAL_HOST:
+        return ("external", url)
+    path = unquote(parsed.path)
+    if parsed.hostname == CANONICAL_HOST or path.startswith("/"):
+        normalized = posixpath.normpath(path or "/")
+    else:
+        normalized = posixpath.normpath(
+            str(PurePosixPath(source).parent / (path or PurePosixPath(source).name))
+        )
+    if normalized in {".", "/"}:
+        target = "index.html"
+    else:
+        target = normalized.lstrip("/")
+        if path.endswith("/"):
+            target = f"{target.rstrip('/')}/index.html"
+    if target.startswith("../") or target == "..":
+        return ("escape", target)
+    return ("local", target)
+
+
+def _srcset(value: str) -> Iterable[str]:
+    for part in value.split(","):
+        candidate = part.strip().split()
+        if candidate:
+            yield candidate[0]
+
+
+def _broken_references(root: Path) -> dict[str, list[dict[str, str]]]:
+    broken_links: list[dict[str, str]] = []
+    broken_assets: list[dict[str, str]] = []
+    external_assets: list[dict[str, str]] = []
+    for path in sorted(root.rglob("*.html")):
+        source = path.relative_to(root).as_posix()
+        soup = BeautifulSoup(path.read_bytes(), "html.parser")
+        candidates: list[tuple[str, str, str]] = []
+        for node in soup.find_all("a", href=True):
+            candidates.append(("link", "href", str(node["href"])))
+        for tag, attribute in HTML_ASSET_ATTRIBUTES:
+            for node in soup.find_all(tag):
+                value = node.get(attribute)
+                if isinstance(value, str) and value:
+                    candidates.append(("asset", attribute, value))
+        for node in soup.find_all("link", href=True):
+            rel = {str(item).casefold() for item in (node.get("rel") or [])}
+            if rel & {"stylesheet", "icon"}:
+                candidates.append(("asset", "href", str(node["href"])))
+        for node in soup.find_all(["img", "source"], srcset=True):
+            for value in _srcset(str(node["srcset"])):
+                candidates.append(("asset", "srcset", value))
+
+        for kind, attribute, url in candidates:
+            resolved = _reference_target(source=source, url=url)
+            if resolved is None:
+                continue
+            disposition, target = resolved
+            record = {
+                "attribute": attribute,
+                "source": source,
+                "target": target,
+                "url": url,
+            }
+            if disposition == "external":
+                if kind == "asset":
+                    external_assets.append(record)
+                continue
+            if disposition == "escape" or not (root / target).is_file():
+                if kind == "link":
+                    broken_links.append(record)
+                else:
+                    broken_assets.append(record)
+    def key(item: dict[str, str]) -> tuple[str, str, str]:
+        return item["source"], item["target"], item["url"]
+
+    return {
+        "assets": sorted(broken_assets, key=key),
+        "external_assets": sorted(external_assets, key=key),
+        "links": sorted(broken_links, key=key),
+    }
+
+
+def _reference_key(record: dict[str, str]) -> str:
+    return f"{record['source']}|{record['target']}"
+
+
+def compare_links_and_assets(
+    preview_root: Path,
+    production_root: Path,
+    *,
+    intentional_links: dict[str, str],
+    intentional_assets: dict[str, str],
+) -> dict[str, Any]:
+    preview = _broken_references(preview_root.resolve())
+    production = _broken_references(production_root.resolve())
+    result: dict[str, Any] = {
+        "external_preview_assets": preview["external_assets"],
+        "external_production_assets": production["external_assets"],
+    }
+    for label, allowlist in (
+        ("links", intentional_links),
+        ("assets", intentional_assets),
+    ):
+        preview_by_key = {_reference_key(item): item for item in preview[label]}
+        production_by_key = {
+            _reference_key(item): item for item in production[label]
+        }
+        new = set(preview_by_key) - set(production_by_key)
+        _check_exact_allowlist(
+            observed=new,
+            allowlist=allowlist,
+            label=f"broken {label}",
+        )
+        result[label] = {
+            "new": [
+                {
+                    **preview_by_key[key],
+                    "reason": allowlist[key],
+                }
+                for key in sorted(new)
+            ],
+            "preview": len(preview_by_key),
+            "production": len(production_by_key),
+            "resolved": [
+                production_by_key[key]
+                for key in sorted(set(production_by_key) - set(preview_by_key))
+            ],
+            "unchanged": len(set(preview_by_key) & set(production_by_key)),
+            "unchanged_records": [
+                preview_by_key[key]
+                for key in sorted(set(preview_by_key) & set(production_by_key))
+            ],
+        }
+    return result
+
+
+def validate_documents(output_root: Path) -> dict[str, Any]:
+    html_files = 0
+    xml_files = 0
+    for path in sorted(output_root.rglob("*.html")):
+        soup = BeautifulSoup(path.read_bytes(), "html.parser")
+        if soup.find("html") is None:
+            raise Cut001ValidationError(
+                f"HTML parse failed: {path.relative_to(output_root).as_posix()}"
+            )
+        html_files += 1
+    for path in sorted(output_root.rglob("*.xml")):
+        try:
+            ET.parse(path)
+        except ET.ParseError as error:
+            raise Cut001ValidationError(
+                f"XML parse failed: {path.relative_to(output_root).as_posix()}: {error}"
+            ) from error
+        xml_files += 1
+    return {"html_files": html_files, "xml_files": xml_files}
+
+
+def validate_notebooks(output_root: Path) -> dict[str, Any]:
+    records: list[dict[str, Any]] = []
+    rows = NOTEBOOK_MANIFEST.read_text(encoding="utf-8").splitlines()
+    header = rows[0].split("\t")
+    for raw in rows[1:]:
+        values = dict(zip(header, raw.split("\t"), strict=True))
+        relative = values["route"].lstrip("/")
+        path = output_root / relative
+        if not path.is_file():
+            raise Cut001ValidationError(f"notebook route is missing: {values['route']}")
+        soup = BeautifulSoup(path.read_bytes(), "html.parser")
+        article = soup.select_one("article.pet-notebook-region")
+        main = soup.select_one("main#main-content")
+        text_length = len(" ".join((article or soup).stripped_strings))
+        if article is None or main is None or text_length < 200:
+            raise Cut001ValidationError(
+                f"notebook is not readable: {values['route']} "
+                f"article={article is not None} main={main is not None} "
+                f"text_length={text_length}"
+            )
+        records.append(
+            {
+                "output": relative,
+                "route": values["route"],
+                "sha256": _sha256(path),
+                "size": path.stat().st_size,
+                "source": values["source"],
+                "text_length": text_length,
+            }
+        )
+    if len(records) != 11:
+        raise Cut001ValidationError(f"expected 11 readable notebooks, got {len(records)}")
+    return {"count": len(records), "records": records}
+
+
+def compare_sitemap(preview_root: Path, production_root: Path) -> dict[str, Any]:
+    preview = sitemap_urls((preview_root / "sitemap.xml").read_bytes())
+    production = sitemap_urls((production_root / "sitemap.xml").read_bytes())
+    missing = sorted(set(production) - set(preview))
+    added = sorted(set(preview) - set(production))
+    if missing or added:
+        raise Cut001ValidationError(
+            f"sitemap routes changed: missing={missing!r} added={added!r}"
+        )
+    return {
+        "added": [],
+        "missing": [],
+        "preview_count": len(preview),
+        "production_count": len(production),
+    }
+
+
+def _route_inventory(output_root: Path) -> dict[str, Any]:
+    baseline = load_json(BASELINE_ROOT / "routes.json")["routes"]
+    by_output: dict[str, list[dict[str, Any]]] = {}
+    for record in baseline:
+        output = record.get("output_path")
+        if output:
+            by_output.setdefault(output, []).append(record)
+    notebook_routes = {
+        line.split("\t")[2]
+        for line in NOTEBOOK_MANIFEST.read_text(encoding="utf-8").splitlines()[1:]
+    }
+    records: list[dict[str, Any]] = []
+    for route, relative in sorted(_html_routes(output_root).items()):
+        path = output_root / relative
+        metadata = _metadata(path)
+        records.append(
+            {
+                "baseline_paths": sorted(
+                    item["path"] for item in by_output.get(relative, [])
+                ),
+                "canonical": metadata["canonical"],
+                "hreflang": metadata["hreflang"],
+                "lang": metadata["lang"],
+                "notebook": route in notebook_routes,
+                "output": relative,
+                "route": route,
+                "sha256": _sha256(path),
+                "simulated_status": 200,
+                "size": path.stat().st_size,
+            }
+        )
+    return {
+        "contract": "nekrasovp-cut001-generated-routes.v1",
+        "count": len(records),
+        "records": records,
+        "status_exceptions": [
+            {
+                "basis": "GitHub Pages treats CNAME as an artifact-only control file",
+                "path": "/CNAME",
+                "simulated_status": 404,
+            },
+            {
+                "basis": "GitHub Pages serves the retained 404.html document",
+                "path": "/__cut001_missing_probe__",
+                "simulated_status": 404,
+            },
+        ],
+    }
+
+
+def _verify_source_and_dependencies(
+    cumulative_report: Path,
+    production_root: Path,
+) -> dict[str, Any]:
+    source_commit = _git("rev-parse", "HEAD")
+    source_tree = _git("rev-parse", "HEAD^{tree}")
+    if _git("rev-parse", f"{BASE_COMMIT}^{{tree}}") != BASE_TREE:
+        raise Cut001ValidationError("CUT-001 base tree no longer matches its contract")
+    ancestor = subprocess.run(
+        ["git", "merge-base", "--is-ancestor", BASE_COMMIT, source_commit],
+        cwd=REPO_ROOT,
+        check=False,
+    )
+    if ancestor.returncode:
+        raise Cut001ValidationError(
+            f"CUT-001 source {source_commit} is not based on {BASE_COMMIT}"
+        )
+    production_head = _git("-C", str(production_root), "rev-parse", "HEAD")
+    if production_head != PRODUCTION_COMMIT:
+        raise Cut001ValidationError(
+            f"production reference drift: expected={PRODUCTION_COMMIT} "
+            f"actual={production_head}"
+        )
+    changed_build_inputs = _git(
+        "diff",
+        "--name-only",
+        BASE_COMMIT,
+        source_commit,
+        "--",
+        *BUILD_INPUT_PATHS,
+    ).splitlines()
+    if changed_build_inputs:
+        raise Cut001ValidationError(
+            f"CUT-001 changed build inputs from exact master: {changed_build_inputs!r}"
+        )
+
+    cumulative = load_json(cumulative_report)
+    if cumulative.get("repository_head") != source_commit:
+        raise Cut001ValidationError(
+            "cumulative report was not generated from the exact CUT-001 source commit"
+        )
+    dependency = cumulative.get("dependency", {})
+    theme = cumulative.get("site006v", {}).get("candidate", {})
+    if dependency.get("plugin_commit") != READER_COMMIT:
+        raise Cut001ValidationError("cumulative reader identity drift")
+    if theme.get("theme_commit") != THEME_COMMIT:
+        raise Cut001ValidationError("cumulative theme identity drift")
+    return {
+        "base_commit": BASE_COMMIT,
+        "base_tree": BASE_TREE,
+        "build_input_diff_from_base": [],
+        "production_commit": production_head,
+        "reader": dependency,
+        "source_commit": source_commit,
+        "source_tree": source_tree,
+        "theme": theme,
+    }
+
+
+def run(args: argparse.Namespace) -> dict[str, Any]:
+    output_root = args.output_root.resolve()
+    production_root = args.production_root.resolve()
+    evidence_root = args.evidence_root.resolve()
+    if not output_root.is_dir() or not production_root.is_dir():
+        raise Cut001ValidationError("preview or production artifact is unavailable")
+    intents = load_json(args.intentional_differences.resolve())
+    if intents.get("production_commit") != PRODUCTION_COMMIT:
+        raise Cut001ValidationError("intentional-difference production identity drift")
+
+    source = _verify_source_and_dependencies(
+        args.cumulative_report.resolve(),
+        production_root,
+    )
+    ops_errors, ops_evidence = validate_artifact(
+        output_root,
+        accepted_migration_contracts=True,
+    )
+    if ops_errors:
+        raise Cut001ValidationError(f"OPS-001 validation failed: {ops_errors!r}")
+
+    routes = compare_routes(
+        output_root,
+        production_root,
+        intentional_added=intents["added_routes"],
+        intentional_missing=intents["missing_routes"],
+    )
+    feeds = compare_feeds(
+        output_root,
+        production_root,
+        intentional_added_feeds=intents["added_feeds"],
+    )
+    canonical = compare_canonical_hreflang(
+        output_root,
+        production_root,
+        intentional=intents["canonical_or_hreflang"],
+    )
+    references = compare_links_and_assets(
+        output_root,
+        production_root,
+        intentional_links=intents["new_broken_links"],
+        intentional_assets=intents["new_broken_assets"],
+    )
+    references["intentional_production_runtime_external"] = [
+        {"reason": reason, "url": url}
+        for url, reason in sorted(
+            intents["production_runtime_external"].items()
+        )
+    ]
+    route_inventory = _route_inventory(output_root)
+    comparison = {
+        "artifact": {
+            "directory_sha256": ops_evidence["artifact_sha256"],
+            "html_files": ops_evidence["html_files"],
+            "xml_files": ops_evidence["xml_files"],
+        },
+        "base001_and_ops001": {
+            "base_parity_errors": ops_evidence["base_parity_errors"],
+            "global_errors": ops_evidence["global_errors"],
+            "reviewed_base_differences": ops_evidence[
+                "reviewed_base_differences"
+            ],
+        },
+        "canonical_hreflang": canonical,
+        "contract": "nekrasovp-cut001-comparison.v1",
+        "documents": validate_documents(output_root),
+        "feeds": feeds,
+        "notebooks": validate_notebooks(output_root),
+        "references": references,
+        "rollback": {
+            "identifier": f"gh-pages@{PRODUCTION_COMMIT}",
+            "instructions": (
+                "Discard the preview. Production remains on legacy gh-pages; "
+                "re-materialize the exact rollback tree from the recorded commit."
+            ),
+        },
+        "routes": routes,
+        "sitemap": compare_sitemap(output_root, production_root),
+        "source": source,
+        "structured_data": validate_structured_data(output_root),
+        "theme_toggle_markup": validate_theme_toggle_markup(output_root),
+    }
+    evidence_root.mkdir(parents=True, exist_ok=True)
+    _write_json(evidence_root / "generated-routes.json", route_inventory)
+    _write_json(evidence_root / "feed-diff.json", feeds)
+    _write_json(evidence_root / "comparison.json", comparison)
+    manifest = build_evidence_manifest(evidence_root, source["source_commit"])
+    _write_json(evidence_root / "manifest.json", manifest)
+    return comparison
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser(description=__doc__)
+    result.add_argument("--output-root", type=Path, required=True)
+    result.add_argument("--production-root", type=Path, required=True)
+    result.add_argument("--cumulative-report", type=Path, required=True)
+    result.add_argument("--evidence-root", type=Path, required=True)
+    result.add_argument(
+        "--intentional-differences",
+        type=Path,
+        default=INTENTIONAL_DIFFERENCES,
+    )
+    return result
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    try:
+        report = run(parser().parse_args(argv))
+    except Exception as error:
+        print(f"CUT-001 validation failed: {error}", file=sys.stderr)
+        return 1
+    print(
+        "CUT-001 machine parity passed: "
+        f"{report['routes']['preview_count']} routes, "
+        f"{report['notebooks']['count']} notebooks, "
+        f"{report['theme_toggle_markup']['checked']} themed HTML documents, "
+        f"artifact {report['artifact']['directory_sha256']}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/migration/ops001/tests/test_cut001.py
+++ b/migration/ops001/tests/test_cut001.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import json
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT))
+
+from migration.cut001.validate import (  # noqa: E402
+    Cut001ValidationError,
+    compare_feeds,
+    compare_routes,
+    validate_structured_data,
+    validate_theme_toggle_markup,
+)
+
+ATOM = "{http://www.w3.org/2005/Atom}"
+
+
+def _page(*, toggle: bool = True, jsonld: object | None = None) -> str:
+    toggle_markup = (
+        '<button data-pet-theme-toggle aria-pressed="false">Theme</button>'
+        if toggle
+        else ""
+    )
+    structured = (
+        f'<script type="application/ld+json">{json.dumps(jsonld)}</script>'
+        if jsonld is not None
+        else ""
+    )
+    return (
+        "<!doctype html><html lang=\"en\"><head>"
+        f"{structured}</head><body><main id=\"main-content\">Readable</main>"
+        f"{toggle_markup}<script src=\"/theme/js/theme.js\"></script></body></html>"
+    )
+
+
+def _feed(path: Path, identifiers: list[str]) -> None:
+    ET.register_namespace("", "http://www.w3.org/2005/Atom")
+    root = ET.Element(f"{ATOM}feed")
+    ET.SubElement(root, f"{ATOM}id").text = "https://nekrasovp.ru/feeds/all.atom.xml"
+    for identifier in identifiers:
+        entry = ET.SubElement(root, f"{ATOM}entry")
+        ET.SubElement(entry, f"{ATOM}id").text = identifier
+        ET.SubElement(
+            entry,
+            f"{ATOM}link",
+            {"href": f"https://nekrasovp.ru/{identifier.rsplit(':', 1)[-1]}.html"},
+        )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    ET.ElementTree(root).write(path, encoding="utf-8", xml_declaration=True)
+
+
+def test_unexplained_added_route_is_red(tmp_path: Path) -> None:
+    production = tmp_path / "production"
+    preview = tmp_path / "preview"
+    production.mkdir()
+    preview.mkdir()
+    (production / "index.html").write_text(_page(), encoding="utf-8")
+    (preview / "index.html").write_text(_page(), encoding="utf-8")
+    (preview / "unexpected.html").write_text(_page(), encoding="utf-8")
+
+    with pytest.raises(Cut001ValidationError, match="unexplained added routes"):
+        compare_routes(preview, production, intentional_added={})
+
+
+def test_changed_historical_feed_id_is_red(tmp_path: Path) -> None:
+    production = tmp_path / "production"
+    preview = tmp_path / "preview"
+    _feed(production / "feeds/all.atom.xml", ["tag:nekrasovp.ru,2020:/historical"])
+    _feed(preview / "feeds/all.atom.xml", ["tag:nekrasovp.ru,2020:/changed"])
+
+    with pytest.raises(Cut001ValidationError, match="historical feed IDs"):
+        compare_feeds(preview, production)
+
+
+def test_invalid_structured_data_is_red(tmp_path: Path) -> None:
+    output = tmp_path / "site"
+    output.mkdir()
+    (output / "index.html").write_text(
+        '<html><script type="application/ld+json">{"broken":</script></html>',
+        encoding="utf-8",
+    )
+
+    with pytest.raises(Cut001ValidationError, match="invalid JSON-LD"):
+        validate_structured_data(output)
+
+
+def test_missing_theme_toggle_on_generated_page_is_red(tmp_path: Path) -> None:
+    output = tmp_path / "site"
+    output.mkdir()
+    (output / "index.html").write_text(_page(toggle=False), encoding="utf-8")
+
+    with pytest.raises(Cut001ValidationError, match="theme toggle contract"):
+        validate_theme_toggle_markup(output)
+
+
+def test_exact_standalone_redirects_are_toggle_exempt(tmp_path: Path) -> None:
+    output = tmp_path / "site"
+    (output / "pages").mkdir(parents=True)
+    (output / "index.html").write_text(_page(), encoding="utf-8")
+    for relative in ("pages/about.html", "pages/services.html"):
+        (output / relative).write_text(
+            "<!doctype html><html lang=\"en\"><head>"
+            '<meta http-equiv="refresh" content="0; url=/">'
+            "</head><body></body></html>",
+            encoding="utf-8",
+        )
+
+    evidence = validate_theme_toggle_markup(output)
+
+    assert evidence["checked"] == 1
+    assert evidence["exempt"] == ["pages/about.html", "pages/services.html"]

--- a/migration/ops001/tests/test_cut001_browser.py
+++ b/migration/ops001/tests/test_cut001_browser.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT))
+
+from migration.cut001.browser_validate import (  # noqa: E402
+    VISUAL_CASES,
+    VISUAL_EQUIVALENCES,
+    BrowserValidationError,
+    _assert_exact_observations,
+    _assert_network,
+    visual_matrix_contract,
+)
+
+
+def test_visual_matrix_contract_covers_the_authoritative_page_types() -> None:
+    contract = visual_matrix_contract()
+
+    assert contract["themes"] == ["dark", "light"]
+    assert contract["viewports"] == ["desktop", "mobile"]
+    assert contract["page_types"] == {
+        "404": {"en", "ru-equivalent"},
+        "archive_deprecated": {"en", "ru-equivalent"},
+        "home": {"en", "ru"},
+        "legacy_markdown": {"en", "ru"},
+        "modern_essay": {"en"},
+        "notebook": {"en", "ru"},
+        "work_about_writing": {"en"},
+    }
+    assert len({case["route"] for case in VISUAL_CASES.values()}) == len(VISUAL_CASES)
+    assert {
+        item["virtual_case"] for item in VISUAL_EQUIVALENCES
+    } == {"404_ru_acceptable", "archive_deprecated_ru"}
+    assert all(
+        item["canonical_case"] in VISUAL_CASES for item in VISUAL_EQUIVALENCES
+    )
+
+
+def test_exact_unchanged_missing_asset_is_browser_evidence() -> None:
+    _assert_network(
+        {
+            "blocked_external": [],
+            "fulfilled_same_origin": [],
+            "missing_same_origin": [
+                {
+                    "resource_type": "image",
+                    "url": "https://nekrasovp.ru/Figure%201.1",
+                }
+            ],
+        },
+        allowed_external_urls=set(),
+        allowed_missing_same_origin_urls={
+            "https://nekrasovp.ru/Figure%201.1",
+        },
+        label="test",
+    )
+
+
+def test_unreviewed_missing_same_origin_asset_is_red() -> None:
+    with pytest.raises(
+        BrowserValidationError,
+        match="requested missing same-origin files",
+    ):
+        _assert_network(
+            {
+                "blocked_external": [],
+                "fulfilled_same_origin": [],
+                "missing_same_origin": [
+                    {
+                        "resource_type": "image",
+                        "url": "https://nekrasovp.ru/unreviewed.png",
+                    }
+                ],
+            },
+            allowed_external_urls=set(),
+            allowed_missing_same_origin_urls={
+                "https://nekrasovp.ru/Figure%201.1",
+            },
+            label="test",
+        )
+
+
+def test_stale_unchanged_missing_asset_allowlist_is_red() -> None:
+    with pytest.raises(BrowserValidationError, match="observation drift"):
+        _assert_exact_observations(
+            expected={"https://nekrasovp.ru/Figure%201.1"},
+            observed=set(),
+            label="test",
+        )

--- a/migration/ops001/tests/test_workflow.py
+++ b/migration/ops001/tests/test_workflow.py
@@ -66,12 +66,24 @@ def test_validate_job_has_one_locked_build_and_gate_path() -> None:
     assert "./scripts/site validate" in joined_runs
     assert "./scripts/site build --output \"$RUNNER_TEMP/ops001-site\"" in joined_runs
     assert "migration/ops001/validate.py" in joined_runs
+    assert "migration/cut001/validate.py" in joined_runs
+    assert "migration/cut001/browser_validate.py" in joined_runs
+    assert "5c24ba21ec8b442e4b5280a47c85fab61165f8ce" in joined_runs
+    assert "027a170ac6c8288347de5353569a089c526afae2" in joined_runs
     assert "./scripts/site test" in joined_runs
     assert "uv sync --locked --all-groups" in joined_runs
     assert "pelican-engineering-theme" in joined_runs
     assert "pelican-jupyter" in joined_runs
     assert steps["Check out the exact site head"]["with"]["fetch-depth"] == 0
     assert steps["Check out the exact site head"]["with"]["persist-credentials"] is False
+    evidence_upload = steps["Upload the CUT-001 evidence package"]["with"]
+    assert evidence_upload == {
+        "name": "cut001-evidence-${{ env.EXPECTED_HEAD }}",
+        "path": "${{ runner.temp }}/cut001-evidence",
+        "if-no-files-found": "error",
+        "include-hidden-files": True,
+        "retention-days": 14,
+    }
 
 
 def test_exact_artifact_handoff_and_official_actions_are_sha_pinned() -> None:


### PR DESCRIPTION
## What

- add a fail-closed CUT-001 machine comparator composed with the existing cumulative and OPS-001 validators;
- record exact route/status, canonical/hreflang, feed ID/entry, sitemap, internal-link/asset, HTML/XML/JSON-LD, notebook, theme, reader, and rollback evidence;
- add the full English/Russian, light/dark, mobile/desktop browser matrix with axe results, exact production references, runtime network gates, and a 147-page theme-toggle sweep;
- publish `ops001-review-<exact-head>` and `cut001-evidence-<exact-head>` from automatically triggered CI;
- add the separate owner visual-review guide.

## Exact scope and provenance

- base: `306028c8ab31a21a1297746b4176916315ba6a23`
- head: `95c3f02ad6fc3589798ba73dc19e39045941235e`
- head tree: `671f023ce65f661af807edccc6a754d66056ce82`
- legacy production reference / rollback: `gh-pages@5c24ba21ec8b442e4b5280a47c85fab61165f8ce`
- theme: `027a170ac6c8288347de5353569a089c526afae2`
- notebook reader: `137e1eb0ea620f1b15fff0ba81725eea23de1b7a`
- build-input diff from exact base: none

## Local exact-head evidence

- full suite: 74 passed;
- scoped Ruff and repository hygiene: passed;
- cumulative validator: two clean builds, 35 Markdown + 11 notebooks, 10 negative gates;
- machine comparison: 149/149 routes, 58/58 sitemap URLs, 95 historical feed-ID occurrences preserved, no missing/added HTML routes, no unexplained broken links/assets, all 11 notebooks readable;
- browser: 26 preview cases, 26 production references, 78 screenshots, 52 axe scans, 147 generated-page toggle cases, 0 outbound requests;
- axe: 0 violations; the English notebook mobile light/dark cases retain two `color-contrast` incomplete groups (3 nodes) for owner review;
- local evidence manifest: 84 files, SHA-256 `8f35c7d9651ea898d3312ef60d7b60708892fe673ac16db4138db8fe72072340`;
- local raw artifact SHA-256 for that exact run: `02acd3ed25a5f57b6c1adca1bdb5ab5129aa84a11ff9e81664f33b310da2d0f2`.

The retained `stock-market-portfolio-optimisation` notebook emits a random `output_widget_view` UUID into its HTML and two feed embeddings. Raw artifact SHA-256 therefore identifies one exact build; cross-build reproducibility is enforced by the cumulative normalized gates.

## Owner gates

This remains a DRAFT. Please use `migration/cut001/OWNER_VISUAL_REVIEW.md` and the hosted exact-head evidence artifact to record one explicit visual decision.

Not performed or authorized: ready, merge, deployment, Pages/DNS/CNAME/gh-pages mutation, CUT-002 variable/environment changes, workflow dispatch/rerun, outreach, release/package publication, or CUT-002/PLUGIN-004B/005/SITE-002 work.